### PR TITLE
feat: scaffold open-source Go auth platform template

### DIFF
--- a/auth-platform-template/.editorconfig
+++ b/auth-platform-template/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.{yml,yaml,json,md,http}]
+indent_style = space
+indent_size = 2

--- a/auth-platform-template/.env.example
+++ b/auth-platform-template/.env.example
@@ -1,0 +1,7 @@
+DB_DSN=postgres://postgres:postgres@pg:5432/auth?sslmode=disable
+REDIS_ADDR=redis:6379
+JWT_SECRET=dev-secret-change-me
+ACCESS_TTL_MIN=15
+REFRESH_TTL_HOURS=168
+CORS_ALLOW_ORIGINS=http://localhost:3000
+CORS_ALLOW_CREDENTIALS=false

--- a/auth-platform-template/.github/workflows/ci.yml
+++ b/auth-platform-template/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: ci
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: auth
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d auth"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 20
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - name: install psql
+        run: sudo apt-get update && sudo apt-get install -y postgresql-client
+      - name: migrate
+        run: psql "postgres://postgres:postgres@localhost:5432/auth?sslmode=disable" -f services/auth-api/migrations/001_init.sql
+      - name: test
+        env:
+          DB_DSN: postgres://postgres:postgres@localhost:5432/auth?sslmode=disable
+          REDIS_ADDR: localhost:6379
+          JWT_SECRET: test-secret
+        run: go test ./... -count=1
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.61

--- a/auth-platform-template/.gitignore
+++ b/auth-platform-template/.gitignore
@@ -1,0 +1,8 @@
+.env
+bin/
+dist/
+coverage.out
+*.log
+.DS_Store
+.idea/
+.vscode/

--- a/auth-platform-template/.golangci.yml
+++ b/auth-platform-template/.golangci.yml
@@ -1,0 +1,14 @@
+run:
+  timeout: 5m
+
+linters:
+  enable:
+    - govet
+    - errcheck
+    - staticcheck
+    - ineffassign
+    - gofmt
+    - goimports
+
+issues:
+  exclude-use-default: false

--- a/auth-platform-template/CHANGELOG.md
+++ b/auth-platform-template/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/auth-platform-template/CODE_OF_CONDUCT.md
+++ b/auth-platform-template/CODE_OF_CONDUCT.md
@@ -1,0 +1,120 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org

--- a/auth-platform-template/CONTRIBUTING.md
+++ b/auth-platform-template/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing
+
+Thanks for contributing!
+
+## Local development
+
+```bash
+cp .env.example .env
+make init
+make smoke
+```
+
+## PR checklist
+
+- [ ] `go test ./... -count=1` passes
+- [ ] `golangci-lint run` passes
+- [ ] API responses follow envelope contract
+- [ ] Docs/examples updated for API changes

--- a/auth-platform-template/LICENSE
+++ b/auth-platform-template/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 auth-platform-template contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/auth-platform-template/Makefile
+++ b/auth-platform-template/Makefile
@@ -1,0 +1,20 @@
+COMPOSE := docker compose -f deploy/docker-compose.yml
+
+.PHONY: up down migrate init smoke test
+
+up:
+	$(COMPOSE) up -d --build
+
+down:
+	$(COMPOSE) down -v
+
+migrate:
+	bash scripts/migrate.sh
+
+init: up migrate
+
+smoke:
+	bash scripts/smoke.sh
+
+test:
+	go test ./... -count=1

--- a/auth-platform-template/README.md
+++ b/auth-platform-template/README.md
@@ -1,0 +1,31 @@
+# auth-platform-template
+
+Open-source style starter template for a multi-tenant auth platform built from day one with two microservices:
+
+- `auth-api` (user auth, token lifecycle)
+- `admin-api` (tenant-scoped admin RBAC APIs)
+
+Tech stack: **Go 1.22**, **Gin**, **PostgreSQL**, **Redis**.
+
+## Quick start
+
+```bash
+cp .env.example .env
+make init
+make smoke
+```
+
+## Services
+
+- auth-api: `http://localhost:8080`
+- admin-api: `http://localhost:8081`
+
+## Highlights
+
+- Unified JSON envelope response with request ID.
+- Middleware-driven centralized error handling.
+- JWT access + refresh rotation with hashed refresh token persistence.
+- Casbin RBAC for admin APIs.
+- Docker Compose one-command bootstrap.
+
+See `docs/` for architecture and API details.

--- a/auth-platform-template/SECURITY.md
+++ b/auth-platform-template/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report vulnerabilities privately by opening a security advisory or contacting maintainers directly.
+Include:
+
+- Affected version/commit
+- Reproduction steps
+- Impact assessment
+- Suggested mitigation (optional)
+
+We will acknowledge within 3 business days and provide status updates until remediation.
+
+## Security Notes
+
+- JWT uses HS256. Use a strong `JWT_SECRET` in all non-dev environments.
+- Refresh tokens are stored only as SHA-256 hashes (`refresh_tokens.token_hash`).
+- Passwords are hashed with bcrypt cost 12.

--- a/auth-platform-template/deploy/docker-compose.yml
+++ b/auth-platform-template/deploy/docker-compose.yml
@@ -1,0 +1,58 @@
+services:
+  pg:
+    image: postgres:16
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_DB: auth
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d auth"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+
+  auth-api:
+    build:
+      context: ..
+      dockerfile: services/auth-api/Dockerfile
+    environment:
+      DB_DSN: postgres://postgres:postgres@pg:5432/auth?sslmode=disable
+      REDIS_ADDR: redis:6379
+      JWT_SECRET: dev-secret-change-me
+      ACCESS_TTL_MIN: "15"
+      REFRESH_TTL_HOURS: "168"
+      CORS_ALLOW_ORIGINS: http://localhost:3000
+      CORS_ALLOW_CREDENTIALS: "false"
+    depends_on:
+      pg:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    ports:
+      - "8080:8080"
+
+  admin-api:
+    build:
+      context: ..
+      dockerfile: services/admin-api/Dockerfile
+    environment:
+      DB_DSN: postgres://postgres:postgres@pg:5432/auth?sslmode=disable
+      REDIS_ADDR: redis:6379
+      JWT_SECRET: dev-secret-change-me
+      ACCESS_TTL_MIN: "15"
+      REFRESH_TTL_HOURS: "168"
+      CORS_ALLOW_ORIGINS: http://localhost:3000
+      CORS_ALLOW_CREDENTIALS: "false"
+      RBAC_DIR: /app/internal/rbac
+    depends_on:
+      pg:
+        condition: service_healthy
+    ports:
+      - "8081:8081"

--- a/auth-platform-template/docs/api.md
+++ b/auth-platform-template/docs/api.md
@@ -1,0 +1,29 @@
+# API Summary
+
+All APIs return envelope:
+
+```json
+{
+  "request_id": "...",
+  "code": 0,
+  "message": "ok",
+  "data": {}
+}
+```
+
+Error envelope uses non-zero code and stable message.
+
+## auth-api
+
+- GET `/healthz`
+- POST `/api/v1/auth/bootstrap`
+- POST `/api/v1/auth/register`
+- POST `/api/v1/auth/login`
+- POST `/api/v1/auth/refresh`
+- POST `/api/v1/auth/logout`
+
+## admin-api
+
+- GET `/healthz`
+- GET `/api/v1/admin/tenants/:tenantId/me/roles`
+- POST `/api/v1/admin/tenants/:tenantId/users/:userId/roles/:role`

--- a/auth-platform-template/docs/architecture.md
+++ b/auth-platform-template/docs/architecture.md
@@ -1,0 +1,20 @@
+# Architecture
+
+This template contains:
+
+- `auth-api`: identity bootstrap/register/login/refresh/logout.
+- `admin-api`: tenant-scoped administrative RBAC APIs.
+- `modules/common-go`: shared libs (config, db, redis, jwt, middleware, envelope).
+
+Both services use Gin middleware chain:
+
+1. Recovery
+2. RequestID
+3. Logger
+4. CORS
+5. ErrorHandler
+
+Data plane:
+
+- PostgreSQL for users/tenants/roles/refresh tokens.
+- Redis for fixed-window rate limiting.

--- a/auth-platform-template/docs/deployment.md
+++ b/auth-platform-template/docs/deployment.md
@@ -1,0 +1,17 @@
+# Deployment
+
+## Docker Compose
+
+```bash
+make init
+```
+
+This starts postgres, redis, auth-api, admin-api and runs migration.
+
+## Smoke test
+
+```bash
+make smoke
+```
+
+The smoke script bootstraps a tenant/user and calls admin endpoint with issued token.

--- a/auth-platform-template/docs/rbac.md
+++ b/auth-platform-template/docs/rbac.md
@@ -1,0 +1,12 @@
+# RBAC
+
+`admin-api` uses Casbin with file model/policy and runtime role checks from DB.
+
+- Domain string: `tenant:<tenantId>`
+- Object: `c.FullPath()`
+- Subject: each role from `user_roles`
+
+Policy highlights:
+
+- `tenant_admin` can access `/api/v1/admin/*` on `tenant:*`.
+- `org_admin` can access `/api/v1/admin/org/*` on `tenant:*`.

--- a/auth-platform-template/examples/http/admin-api.http
+++ b/auth-platform-template/examples/http/admin-api.http
@@ -1,0 +1,7 @@
+### me roles
+GET http://localhost:8081/api/v1/admin/tenants/{{tenant_id}}/me/roles
+Authorization: Bearer {{access_token}}
+
+### assign role
+POST http://localhost:8081/api/v1/admin/tenants/{{tenant_id}}/users/{{user_id}}/roles/org_admin
+Authorization: Bearer {{access_token}}

--- a/auth-platform-template/examples/http/auth-api.http
+++ b/auth-platform-template/examples/http/auth-api.http
@@ -1,0 +1,27 @@
+### bootstrap
+POST http://localhost:8080/api/v1/auth/bootstrap
+Content-Type: application/json
+
+{
+  "email": "demo@example.com",
+  "password": "passw0rd!",
+  "tenant_name": "demo-tenant"
+}
+
+### login
+POST http://localhost:8080/api/v1/auth/login
+Content-Type: application/json
+
+{
+  "email": "demo@example.com",
+  "password": "passw0rd!",
+  "tenant_id": "{{tenant_id}}"
+}
+
+### refresh
+POST http://localhost:8080/api/v1/auth/refresh
+Content-Type: application/json
+
+{
+  "refresh_token": "{{refresh_token}}"
+}

--- a/auth-platform-template/examples/postman/collection.json
+++ b/auth-platform-template/examples/postman/collection.json
@@ -1,0 +1,73 @@
+{
+  "info": {
+    "name": "auth-platform-template",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {"key": "base_url_auth", "value": "http://localhost:8080"},
+    {"key": "base_url_admin", "value": "http://localhost:8081"},
+    {"key": "access_token", "value": ""},
+    {"key": "refresh_token", "value": ""},
+    {"key": "tenant_id", "value": ""}
+  ],
+  "item": [
+    {
+      "name": "bootstrap",
+      "request": {
+        "method": "POST",
+        "header": [{"key": "Content-Type", "value": "application/json"}],
+        "url": "{{base_url_auth}}/api/v1/auth/bootstrap",
+        "body": {"mode": "raw", "raw": "{\n  \"email\": \"postman@example.com\",\n  \"password\": \"passw0rd!\",\n  \"tenant_name\": \"postman-tenant\"\n}"}
+      },
+      "event": [{"listen": "test", "script": {"exec": [
+        "const b = pm.response.json();",
+        "pm.test('envelope code=0', ()=> pm.expect(b.code).to.eql(0));",
+        "pm.collectionVariables.set('access_token', b.data.access_token);",
+        "pm.collectionVariables.set('refresh_token', b.data.refresh_token);",
+        "pm.collectionVariables.set('tenant_id', b.data.tenant_id);"
+      ]}}]
+    },
+    {
+      "name": "login",
+      "request": {
+        "method": "POST",
+        "header": [{"key": "Content-Type", "value": "application/json"}],
+        "url": "{{base_url_auth}}/api/v1/auth/login",
+        "body": {"mode": "raw", "raw": "{\n  \"email\": \"postman@example.com\",\n  \"password\": \"passw0rd!\",\n  \"tenant_id\": \"{{tenant_id}}\"\n}"}
+      },
+      "event": [{"listen": "test", "script": {"exec": [
+        "const b = pm.response.json();",
+        "pm.test('envelope code=0', ()=> pm.expect(b.code).to.eql(0));",
+        "pm.collectionVariables.set('access_token', b.data.access_token);",
+        "pm.collectionVariables.set('refresh_token', b.data.refresh_token);"
+      ]}}]
+    },
+    {
+      "name": "refresh",
+      "request": {
+        "method": "POST",
+        "header": [{"key": "Content-Type", "value": "application/json"}],
+        "url": "{{base_url_auth}}/api/v1/auth/refresh",
+        "body": {"mode": "raw", "raw": "{\n  \"refresh_token\": \"{{refresh_token}}\"\n}"}
+      },
+      "event": [{"listen": "test", "script": {"exec": [
+        "const b = pm.response.json();",
+        "pm.test('envelope code=0', ()=> pm.expect(b.code).to.eql(0));",
+        "pm.collectionVariables.set('access_token', b.data.access_token);",
+        "pm.collectionVariables.set('refresh_token', b.data.refresh_token);"
+      ]}}]
+    },
+    {
+      "name": "admin me roles",
+      "request": {
+        "method": "GET",
+        "header": [{"key": "Authorization", "value": "Bearer {{access_token}}"}],
+        "url": "{{base_url_admin}}/api/v1/admin/tenants/{{tenant_id}}/me/roles"
+      },
+      "event": [{"listen": "test", "script": {"exec": [
+        "const b = pm.response.json();",
+        "pm.test('envelope code=0', ()=> pm.expect(b.code).to.eql(0));"
+      ]}}]
+    }
+  ]
+}

--- a/auth-platform-template/go.mod
+++ b/auth-platform-template/go.mod
@@ -1,0 +1,3 @@
+module auth-platform-template
+
+go 1.22

--- a/auth-platform-template/modules/common-go/go.mod
+++ b/auth-platform-template/modules/common-go/go.mod
@@ -1,0 +1,11 @@
+module auth-platform-template/modules/common-go
+
+go 1.22
+
+require (
+	github.com/gin-gonic/gin v1.10.0
+	github.com/google/uuid v1.6.0
+	github.com/golang-jwt/jwt/v5 v5.2.1
+	github.com/jackc/pgx/v5 v5.7.2
+	github.com/redis/go-redis/v9 v9.7.1
+)

--- a/auth-platform-template/modules/common-go/pkg/auth/jwt/jwt.go
+++ b/auth-platform-template/modules/common-go/pkg/auth/jwt/jwt.go
@@ -1,0 +1,48 @@
+package jwt
+
+import (
+	"errors"
+	"time"
+
+	jwtv5 "github.com/golang-jwt/jwt/v5"
+)
+
+type Claims struct {
+	UID string `json:"uid"`
+	TID string `json:"tid"`
+	Typ string `json:"typ"`
+	jwtv5.RegisteredClaims
+}
+
+func Sign(secret string, uid string, tid string, typ string, ttl time.Duration) (string, error) {
+	now := time.Now()
+	claims := Claims{
+		UID: uid,
+		TID: tid,
+		Typ: typ,
+		RegisteredClaims: jwtv5.RegisteredClaims{
+			IssuedAt:  jwtv5.NewNumericDate(now),
+			ExpiresAt: jwtv5.NewNumericDate(now.Add(ttl)),
+			Subject:   uid,
+		},
+	}
+	token := jwtv5.NewWithClaims(jwtv5.SigningMethodHS256, claims)
+	return token.SignedString([]byte(secret))
+}
+
+func Parse(secret, tokenStr string) (*Claims, error) {
+	t, err := jwtv5.ParseWithClaims(tokenStr, &Claims{}, func(token *jwtv5.Token) (any, error) {
+		if token.Method != jwtv5.SigningMethodHS256 {
+			return nil, errors.New("invalid_signing_method")
+		}
+		return []byte(secret), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	claims, ok := t.Claims.(*Claims)
+	if !ok || !t.Valid {
+		return nil, errors.New("invalid_token")
+	}
+	return claims, nil
+}

--- a/auth-platform-template/modules/common-go/pkg/cache/redis/redis.go
+++ b/auth-platform-template/modules/common-go/pkg/cache/redis/redis.go
@@ -1,0 +1,15 @@
+package redis
+
+import (
+	"context"
+
+	goredis "github.com/redis/go-redis/v9"
+)
+
+func New(ctx context.Context, addr string) (*goredis.Client, error) {
+	c := goredis.NewClient(&goredis.Options{Addr: addr})
+	if err := c.Ping(ctx).Err(); err != nil {
+		return nil, err
+	}
+	return c, nil
+}

--- a/auth-platform-template/modules/common-go/pkg/cfg/env.go
+++ b/auth-platform-template/modules/common-go/pkg/cfg/env.go
@@ -1,0 +1,55 @@
+package cfg
+
+import (
+	"os"
+	"strconv"
+	"strings"
+)
+
+func GetString(key, def string) string {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return def
+	}
+	return v
+}
+
+func GetInt(key string, def int) int {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return def
+	}
+	return n
+}
+
+func GetBool(key string, def bool) bool {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return def
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return def
+	}
+	return b
+}
+
+func GetList(key string) []string {
+	raw := strings.TrimSpace(os.Getenv(key))
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		s := strings.TrimSpace(p)
+		if s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/auth-platform-template/modules/common-go/pkg/db/pgsql/pg.go
+++ b/auth-platform-template/modules/common-go/pkg/db/pgsql/pg.go
@@ -1,0 +1,15 @@
+package pgsql
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func New(ctx context.Context, dsn string) (*pgxpool.Pool, error) {
+	cfg, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		return nil, err
+	}
+	return pgxpool.NewWithConfig(ctx, cfg)
+}

--- a/auth-platform-template/modules/common-go/pkg/httpx/apperr/apperr.go
+++ b/auth-platform-template/modules/common-go/pkg/httpx/apperr/apperr.go
@@ -1,0 +1,72 @@
+package apperr
+
+import (
+	"errors"
+	"net/http"
+
+	"auth-platform-template/modules/common-go/pkg/httpx/errcode"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+type AppError struct {
+	HTTPStatus int
+	Code       int
+	Message    string
+	Data       map[string]any
+	Err        error
+}
+
+func (e *AppError) Error() string {
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	return e.Message
+}
+
+func (e *AppError) Unwrap() error { return e.Err }
+
+func New(httpStatus, code int, msg string, err error) *AppError {
+	return &AppError{HTTPStatus: httpStatus, Code: code, Message: msg, Err: err}
+}
+
+func (e *AppError) WithData(data map[string]any) *AppError {
+	e.Data = data
+	return e
+}
+
+func BadRequest(err error) *AppError {
+	return New(http.StatusBadRequest, errcode.BadRequest, "bad_request", err)
+}
+func Unauthorized(err error) *AppError {
+	return New(http.StatusUnauthorized, errcode.Unauthorized, "unauthorized", err)
+}
+func Forbidden(err error) *AppError {
+	return New(http.StatusForbidden, errcode.Forbidden, "forbidden", err)
+}
+func NotFound(err error) *AppError {
+	return New(http.StatusNotFound, errcode.NotFound, "not_found", err)
+}
+func Conflict(err error) *AppError {
+	return New(http.StatusConflict, errcode.Conflict, "conflict", err)
+}
+func RateLimited(err error) *AppError {
+	return New(http.StatusTooManyRequests, errcode.RateLimited, "rate_limited", err)
+}
+
+func Normalize(err error) *AppError {
+	if err == nil {
+		return New(http.StatusInternalServerError, errcode.InternalError, "internal_error", errors.New("nil_error"))
+	}
+	var ae *AppError
+	if errors.As(err, &ae) {
+		return ae
+	}
+	var pge *pgconn.PgError
+	if errors.As(err, &pge) {
+		if pge.Code == "23505" {
+			return Conflict(err).WithData(map[string]any{"reason": "unique_violation"})
+		}
+		return New(http.StatusInternalServerError, errcode.DBError, "db_error", err)
+	}
+	return New(http.StatusInternalServerError, errcode.InternalError, "internal_error", err)
+}

--- a/auth-platform-template/modules/common-go/pkg/httpx/errcode/errcode.go
+++ b/auth-platform-template/modules/common-go/pkg/httpx/errcode/errcode.go
@@ -1,0 +1,13 @@
+package errcode
+
+const (
+	OK            = 0
+	BadRequest    = 1001
+	Unauthorized  = 1002
+	Forbidden     = 1003
+	NotFound      = 1004
+	Conflict      = 1005
+	RateLimited   = 1006
+	DBError       = 2001
+	InternalError = 9000
+)

--- a/auth-platform-template/modules/common-go/pkg/httpx/ginmid/authn.go
+++ b/auth-platform-template/modules/common-go/pkg/httpx/ginmid/authn.go
@@ -1,0 +1,31 @@
+package ginmid
+
+import (
+	"errors"
+	"strings"
+
+	ajwt "auth-platform-template/modules/common-go/pkg/auth/jwt"
+	"auth-platform-template/modules/common-go/pkg/httpx/apperr"
+	"github.com/gin-gonic/gin"
+)
+
+func AuthN(secret string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		raw := strings.TrimSpace(c.GetHeader("Authorization"))
+		if !strings.HasPrefix(raw, "Bearer ") {
+			_ = c.Error(apperr.Unauthorized(errors.New("missing_bearer")))
+			c.Abort()
+			return
+		}
+		token := strings.TrimSpace(strings.TrimPrefix(raw, "Bearer "))
+		claims, err := ajwt.Parse(secret, token)
+		if err != nil || claims.Typ != "access" {
+			_ = c.Error(apperr.Unauthorized(errors.New("invalid_access_token")))
+			c.Abort()
+			return
+		}
+		c.Set("uid", claims.UID)
+		c.Set("tid", claims.TID)
+		c.Next()
+	}
+}

--- a/auth-platform-template/modules/common-go/pkg/httpx/ginmid/cors.go
+++ b/auth-platform-template/modules/common-go/pkg/httpx/ginmid/cors.go
@@ -1,0 +1,35 @@
+package ginmid
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+func CORS(allowOrigins []string, allowCredentials bool) gin.HandlerFunc {
+	allowed := map[string]struct{}{}
+	for _, o := range allowOrigins {
+		allowed[strings.TrimSpace(o)] = struct{}{}
+	}
+
+	return func(c *gin.Context) {
+		origin := strings.TrimSpace(c.GetHeader("Origin"))
+		if _, ok := allowed[origin]; ok {
+			c.Header("Access-Control-Allow-Origin", origin)
+			c.Header("Vary", "Origin")
+		}
+		if allowCredentials {
+			c.Header("Access-Control-Allow-Credentials", "true")
+		}
+		c.Header("Access-Control-Allow-Methods", "GET,POST,PUT,PATCH,DELETE,OPTIONS")
+		c.Header("Access-Control-Allow-Headers", "Authorization,Content-Type,X-Request-Id")
+		c.Header("Access-Control-Expose-Headers", "X-Request-Id")
+
+		if c.Request.Method == "OPTIONS" {
+			c.Status(204)
+			c.Abort()
+			return
+		}
+		c.Next()
+	}
+}

--- a/auth-platform-template/modules/common-go/pkg/httpx/ginmid/error_handler.go
+++ b/auth-platform-template/modules/common-go/pkg/httpx/ginmid/error_handler.go
@@ -1,0 +1,22 @@
+package ginmid
+
+import (
+	"auth-platform-template/modules/common-go/pkg/httpx/apperr"
+	"auth-platform-template/modules/common-go/pkg/httpx/resp"
+	"github.com/gin-gonic/gin"
+)
+
+func ErrorHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Next()
+		if len(c.Errors) == 0 || c.Writer.Written() {
+			return
+		}
+		ae := apperr.Normalize(c.Errors.Last().Err)
+		data := ae.Data
+		if data == nil {
+			data = map[string]any{}
+		}
+		resp.Fail(c, ae.HTTPStatus, ae.Code, ae.Message, data)
+	}
+}

--- a/auth-platform-template/modules/common-go/pkg/httpx/ginmid/logger.go
+++ b/auth-platform-template/modules/common-go/pkg/httpx/ginmid/logger.go
@@ -1,0 +1,21 @@
+package ginmid
+
+import (
+	"log"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+func Logger() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		start := time.Now()
+		c.Next()
+		lat := time.Since(start).Milliseconds()
+		rid, _ := c.Get("request_id")
+		uid, _ := c.Get("uid")
+		tid, _ := c.Get("tid")
+		log.Printf("request_id=%v uid=%v tid=%v method=%s path=%s status=%d latency_ms=%d",
+			rid, uid, tid, c.Request.Method, c.FullPath(), c.Writer.Status(), lat)
+	}
+}

--- a/auth-platform-template/modules/common-go/pkg/httpx/ginmid/ratelimit.go
+++ b/auth-platform-template/modules/common-go/pkg/httpx/ginmid/ratelimit.go
@@ -1,0 +1,38 @@
+package ginmid
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"auth-platform-template/modules/common-go/pkg/httpx/apperr"
+	"github.com/gin-gonic/gin"
+	goredis "github.com/redis/go-redis/v9"
+)
+
+func RateLimit(rdb *goredis.Client, keyPrefix string, limit int, window time.Duration) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if rdb == nil {
+			c.Next()
+			return
+		}
+		ctx := context.Background()
+		key := fmt.Sprintf("%s:%s", keyPrefix, c.ClientIP())
+		n, err := rdb.Incr(ctx, key).Result()
+		if err != nil {
+			_ = c.Error(apperr.RateLimited(err))
+			c.Abort()
+			return
+		}
+		if n == 1 {
+			_ = rdb.Expire(ctx, key, window).Err()
+		}
+		if int(n) > limit {
+			_ = c.Error(apperr.RateLimited(errors.New("too_many_requests")))
+			c.Abort()
+			return
+		}
+		c.Next()
+	}
+}

--- a/auth-platform-template/modules/common-go/pkg/httpx/ginmid/requestid.go
+++ b/auth-platform-template/modules/common-go/pkg/httpx/ginmid/requestid.go
@@ -1,0 +1,20 @@
+package ginmid
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+func RequestID() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		rid := strings.TrimSpace(c.GetHeader("X-Request-Id"))
+		if rid == "" {
+			rid = uuid.NewString()
+		}
+		c.Set("request_id", rid)
+		c.Writer.Header().Set("X-Request-Id", rid)
+		c.Next()
+	}
+}

--- a/auth-platform-template/modules/common-go/pkg/httpx/ginmid/wrap.go
+++ b/auth-platform-template/modules/common-go/pkg/httpx/ginmid/wrap.go
@@ -1,0 +1,13 @@
+package ginmid
+
+import "github.com/gin-gonic/gin"
+
+type HandlerE func(*gin.Context) error
+
+func Wrap(h HandlerE) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if err := h(c); err != nil {
+			_ = c.Error(err)
+		}
+	}
+}

--- a/auth-platform-template/modules/common-go/pkg/httpx/resp/resp.go
+++ b/auth-platform-template/modules/common-go/pkg/httpx/resp/resp.go
@@ -1,0 +1,31 @@
+package resp
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+type Envelope struct {
+	RequestID string `json:"request_id"`
+	Code      int    `json:"code"`
+	Message   string `json:"message"`
+	Data      any    `json:"data"`
+}
+
+func requestID(c *gin.Context) string {
+	if v, ok := c.Get("request_id"); ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+func OK(c *gin.Context, data any) {
+	c.JSON(http.StatusOK, Envelope{RequestID: requestID(c), Code: 0, Message: "ok", Data: data})
+}
+
+func Fail(c *gin.Context, httpStatus int, code int, message string, data any) {
+	c.JSON(httpStatus, Envelope{RequestID: requestID(c), Code: code, Message: message, Data: data})
+}

--- a/auth-platform-template/modules/common-go/pkg/util/token.go
+++ b/auth-platform-template/modules/common-go/pkg/util/token.go
@@ -1,0 +1,14 @@
+package util
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+)
+
+func RandomToken(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}

--- a/auth-platform-template/scripts/migrate.sh
+++ b/auth-platform-template/scripts/migrate.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+docker compose -f deploy/docker-compose.yml exec -T pg \
+  psql -U postgres -d auth < services/auth-api/migrations/001_init.sql
+
+echo "migrate ok"

--- a/auth-platform-template/scripts/seed.sh
+++ b/auth-platform-template/scripts/seed.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+curl -sS -X POST http://localhost:8080/api/v1/auth/bootstrap \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"seed@example.com","password":"passw0rd!","tenant_name":"seed-tenant"}'
+
+echo

--- a/auth-platform-template/scripts/smoke.sh
+++ b/auth-platform-template/scripts/smoke.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BOOTSTRAP=$(curl -sS -X POST http://localhost:8080/api/v1/auth/bootstrap \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"smoke@example.com","password":"passw0rd!","tenant_name":"smoke-tenant"}')
+
+read -r CODE ACCESS TENANT < <(BOOTSTRAP_JSON="$BOOTSTRAP" python3 - <<'PY'
+import json, os
+b=json.loads(os.environ['BOOTSTRAP_JSON'])
+print(b.get('code'), b.get('data',{}).get('access_token',''), b.get('data',{}).get('tenant_id',''))
+PY
+)
+
+if [[ "$CODE" != "0" || -z "$ACCESS" || -z "$TENANT" ]]; then
+  echo "bootstrap failed: $BOOTSTRAP"
+  exit 1
+fi
+
+ME=$(curl -sS -X GET "http://localhost:8081/api/v1/admin/tenants/${TENANT}/me/roles" \
+  -H "Authorization: Bearer ${ACCESS}")
+
+ME_CODE=$(ME_JSON="$ME" python3 - <<'PY'
+import json, os
+print(json.loads(os.environ['ME_JSON']).get('code'))
+PY
+)
+
+if [[ "$ME_CODE" != "0" ]]; then
+  echo "admin me/roles failed: $ME"
+  exit 1
+fi
+
+echo "smoke ok"

--- a/auth-platform-template/services/admin-api/Dockerfile
+++ b/auth-platform-template/services/admin-api/Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1
+FROM golang:1.22 AS build
+WORKDIR /src
+COPY go.work ./
+COPY modules/common-go ./modules/common-go
+COPY services/admin-api ./services/admin-api
+WORKDIR /src/services/admin-api
+RUN go mod download && go build -o /out/admin-api ./cmd/admin-api
+
+FROM gcr.io/distroless/base-debian12
+WORKDIR /app
+COPY --from=build /out/admin-api /app/admin-api
+COPY --from=build /src/services/admin-api/internal/rbac /app/internal/rbac
+EXPOSE 8081
+ENTRYPOINT ["/app/admin-api"]

--- a/auth-platform-template/services/admin-api/go.mod
+++ b/auth-platform-template/services/admin-api/go.mod
@@ -1,0 +1,12 @@
+module auth-platform-template/services/admin-api
+
+go 1.22
+
+require (
+	auth-platform-template/modules/common-go v0.0.0
+	github.com/casbin/casbin/v2 v2.98.0
+	github.com/gin-gonic/gin v1.10.0
+	github.com/jackc/pgx/v5 v5.7.2
+)
+
+replace auth-platform-template/modules/common-go => ../../modules/common-go

--- a/auth-platform-template/services/admin-api/internal/handler/handler.go
+++ b/auth-platform-template/services/admin-api/internal/handler/handler.go
@@ -1,0 +1,74 @@
+package handler
+
+import (
+	"fmt"
+	"net/http"
+
+	"auth-platform-template/modules/common-go/pkg/httpx/apperr"
+	"auth-platform-template/modules/common-go/pkg/httpx/errcode"
+	"auth-platform-template/modules/common-go/pkg/httpx/resp"
+	"auth-platform-template/services/admin-api/internal/store"
+	"github.com/casbin/casbin/v2"
+	"github.com/gin-gonic/gin"
+)
+
+type Handler struct {
+	Store    *store.Store
+	Enforcer *casbin.Enforcer
+}
+
+func (h *Handler) Healthz(c *gin.Context) error {
+	resp.OK(c, map[string]any{"status": "ok"})
+	return nil
+}
+
+func (h *Handler) MeRoles(c *gin.Context) error {
+	uid, _ := c.Get("uid")
+	tid := c.Param("tenantId")
+	roles, err := h.Store.RolesForUser(c, tid, uid.(string))
+	if err != nil {
+		return err
+	}
+	if err := h.enforce(c, roles, tid); err != nil {
+		return err
+	}
+	resp.OK(c, map[string]any{"roles": roles})
+	return nil
+}
+
+func (h *Handler) AssignRole(c *gin.Context) error {
+	uid, _ := c.Get("uid")
+	tid := c.Param("tenantId")
+	roles, err := h.Store.RolesForUser(c, tid, uid.(string))
+	if err != nil {
+		return err
+	}
+	if err = h.enforce(c, roles, tid); err != nil {
+		return err
+	}
+	if err = h.Store.AssignRole(c, tid, c.Param("userId"), c.Param("role")); err != nil {
+		return err
+	}
+	resp.OK(c, map[string]any{"assigned": true})
+	return nil
+}
+
+func (h *Handler) enforce(c *gin.Context, roles []string, tid string) error {
+	dom := fmt.Sprintf("tenant:%s", tid)
+	obj := c.FullPath()
+	act := c.Request.Method
+	for _, role := range roles {
+		ok, err := h.Enforcer.Enforce(role, dom, obj, act)
+		if err != nil {
+			return err
+		}
+		if ok {
+			return nil
+		}
+	}
+	return apperr.Forbidden(nil).WithData(map[string]any{"reason": "rbac_denied", "code": errcode.Forbidden})
+}
+
+func NotFound(c *gin.Context) {
+	resp.Fail(c, http.StatusNotFound, errcode.NotFound, "not_found", map[string]any{"reason": "route_not_found"})
+}

--- a/auth-platform-template/services/admin-api/internal/handler/middleware.go
+++ b/auth-platform-template/services/admin-api/internal/handler/middleware.go
@@ -1,0 +1,21 @@
+package handler
+
+import (
+	"errors"
+
+	"auth-platform-template/modules/common-go/pkg/httpx/apperr"
+	"github.com/gin-gonic/gin"
+)
+
+func MustTenantMatch() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		tid, _ := c.Get("tid")
+		pathTid := c.Param("tenantId")
+		if tid == nil || tid.(string) != pathTid {
+			_ = c.Error(apperr.Forbidden(errors.New("tenant_mismatch")))
+			c.Abort()
+			return
+		}
+		c.Next()
+	}
+}

--- a/auth-platform-template/services/admin-api/internal/rbac/model.conf
+++ b/auth-platform-template/services/admin-api/internal/rbac/model.conf
@@ -1,0 +1,14 @@
+[request_definition]
+r = sub, dom, obj, act
+
+[policy_definition]
+p = sub, dom, obj, act
+
+[role_definition]
+g = _, _
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = r.sub == p.sub && keyMatch2(r.dom, p.dom) && keyMatch2(r.obj, p.obj) && regexMatch(r.act, p.act)

--- a/auth-platform-template/services/admin-api/internal/rbac/policy.csv
+++ b/auth-platform-template/services/admin-api/internal/rbac/policy.csv
@@ -1,0 +1,2 @@
+p, tenant_admin, tenant:*, /api/v1/admin/*, (GET|POST|PUT|PATCH|DELETE)
+p, org_admin, tenant:*, /api/v1/admin/org/*, (GET|POST|PUT|PATCH|DELETE)

--- a/auth-platform-template/services/admin-api/internal/store/store.go
+++ b/auth-platform-template/services/admin-api/internal/store/store.go
@@ -1,0 +1,31 @@
+package store
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type Store struct{ DB *pgxpool.Pool }
+
+func (s *Store) RolesForUser(ctx context.Context, tenantID, userID string) ([]string, error) {
+	rows, err := s.DB.Query(ctx, `select role from user_roles where tenant_id=$1 and user_id=$2`, tenantID, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	roles := []string{}
+	for rows.Next() {
+		var r string
+		if err := rows.Scan(&r); err != nil {
+			return nil, err
+		}
+		roles = append(roles, r)
+	}
+	return roles, rows.Err()
+}
+
+func (s *Store) AssignRole(ctx context.Context, tenantID, userID, role string) error {
+	_, err := s.DB.Exec(ctx, `insert into user_roles(tenant_id,user_id,role,created_at) values($1,$2,$3,now()) on conflict do nothing`, tenantID, userID, role)
+	return err
+}

--- a/auth-platform-template/services/auth-api/Dockerfile
+++ b/auth-platform-template/services/auth-api/Dockerfile
@@ -1,0 +1,14 @@
+# syntax=docker/dockerfile:1
+FROM golang:1.22 AS build
+WORKDIR /src
+COPY go.work ./
+COPY modules/common-go ./modules/common-go
+COPY services/auth-api ./services/auth-api
+WORKDIR /src/services/auth-api
+RUN go mod download && go build -o /out/auth-api ./cmd/auth-api
+
+FROM gcr.io/distroless/base-debian12
+WORKDIR /app
+COPY --from=build /out/auth-api /app/auth-api
+EXPOSE 8080
+ENTRYPOINT ["/app/auth-api"]

--- a/auth-platform-template/services/auth-api/go.mod
+++ b/auth-platform-template/services/auth-api/go.mod
@@ -1,0 +1,14 @@
+module auth-platform-template/services/auth-api
+
+go 1.22
+
+require (
+	auth-platform-template/modules/common-go v0.0.0
+	github.com/gin-gonic/gin v1.10.0
+	github.com/google/uuid v1.6.0
+	github.com/jackc/pgx/v5 v5.7.2
+	github.com/redis/go-redis/v9 v9.7.1
+	golang.org/x/crypto v0.32.0
+)
+
+replace auth-platform-template/modules/common-go => ../../modules/common-go

--- a/auth-platform-template/services/auth-api/internal/handler/handler.go
+++ b/auth-platform-template/services/auth-api/internal/handler/handler.go
@@ -1,0 +1,154 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	ajwt "auth-platform-template/modules/common-go/pkg/auth/jwt"
+	"auth-platform-template/modules/common-go/pkg/httpx/apperr"
+	"auth-platform-template/modules/common-go/pkg/httpx/resp"
+	"auth-platform-template/modules/common-go/pkg/util"
+	"auth-platform-template/services/auth-api/internal/store"
+	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5"
+)
+
+type Handler struct {
+	Store      *store.Store
+	JWTSecret  string
+	AccessTTL  time.Duration
+	RefreshTTL time.Duration
+}
+
+type authReq struct {
+	Email    string `json:"email" binding:"required,email"`
+	Password string `json:"password" binding:"required,min=6"`
+	TenantID string `json:"tenant_id"`
+	Tenant   string `json:"tenant_name"`
+}
+
+func (h *Handler) Healthz(c *gin.Context) error {
+	resp.OK(c, map[string]any{"status": "ok"})
+	return nil
+}
+
+func (h *Handler) Bootstrap(c *gin.Context) error {
+	var req authReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		return apperr.BadRequest(err)
+	}
+	if strings.TrimSpace(req.Tenant) == "" {
+		return apperr.BadRequest(errors.New("tenant_name_required"))
+	}
+	res, err := h.Store.Bootstrap(c, req.Email, req.Password, req.Tenant)
+	if err != nil {
+		if err.Error() == "invalid_password" {
+			return apperr.Unauthorized(err)
+		}
+		return err
+	}
+	at, rt, err := h.issueTokens(c, res.UserID, res.TenantID)
+	if err != nil {
+		return err
+	}
+	resp.OK(c, map[string]any{"user_id": res.UserID, "tenant_id": res.TenantID, "access_token": at, "refresh_token": rt})
+	return nil
+}
+
+func (h *Handler) Register(c *gin.Context) error {
+	var req authReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		return apperr.BadRequest(err)
+	}
+	uid, err := h.Store.Register(c, req.Email, req.Password)
+	if err != nil {
+		return err
+	}
+	resp.OK(c, map[string]any{"user_id": uid})
+	return nil
+}
+
+func (h *Handler) Login(c *gin.Context) error {
+	var req authReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		return apperr.BadRequest(err)
+	}
+	if strings.TrimSpace(req.TenantID) == "" {
+		return apperr.BadRequest(errors.New("tenant_id_required"))
+	}
+	uid, err := h.Store.Login(c, req.Email, req.Password, req.TenantID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) || err.Error() == "invalid_password" {
+			return apperr.Unauthorized(err)
+		}
+		return err
+	}
+	at, rt, err := h.issueTokens(c, uid, req.TenantID)
+	if err != nil {
+		return err
+	}
+	resp.OK(c, map[string]any{"user_id": uid, "tenant_id": req.TenantID, "access_token": at, "refresh_token": rt})
+	return nil
+}
+
+func (h *Handler) Refresh(c *gin.Context) error {
+	var req struct {
+		RefreshToken string `json:"refresh_token" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		return apperr.BadRequest(err)
+	}
+	newRT, err := util.RandomToken(32)
+	if err != nil {
+		return err
+	}
+	uid, tid, err := h.Store.RotateRefreshToken(c, req.RefreshToken, newRT, time.Now().Add(h.RefreshTTL))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return apperr.Unauthorized(err)
+		}
+		return err
+	}
+	at, err := ajwt.Sign(h.JWTSecret, uid, tid, "access", h.AccessTTL)
+	if err != nil {
+		return err
+	}
+	resp.OK(c, map[string]any{"access_token": at, "refresh_token": newRT, "tenant_id": tid, "user_id": uid})
+	return nil
+}
+
+func (h *Handler) Logout(c *gin.Context) error {
+	var req struct {
+		RefreshToken string `json:"refresh_token" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		return apperr.BadRequest(err)
+	}
+	if err := h.Store.RevokeRefreshToken(c, req.RefreshToken); err != nil {
+		return err
+	}
+	resp.OK(c, map[string]any{"revoked": true})
+	return nil
+}
+
+func (h *Handler) issueTokens(ctx context.Context, uid, tid string) (string, string, error) {
+	at, err := ajwt.Sign(h.JWTSecret, uid, tid, "access", h.AccessTTL)
+	if err != nil {
+		return "", "", err
+	}
+	rt, err := util.RandomToken(32)
+	if err != nil {
+		return "", "", err
+	}
+	if err = h.Store.SaveRefreshToken(ctx, rt, uid, tid, time.Now().Add(h.RefreshTTL)); err != nil {
+		return "", "", err
+	}
+	return at, rt, nil
+}
+
+func NotFound(c *gin.Context) {
+	resp.Fail(c, http.StatusNotFound, 1004, "not_found", map[string]any{"reason": "route_not_found"})
+}

--- a/auth-platform-template/services/auth-api/migrations/001_init.sql
+++ b/auth-platform-template/services/auth-api/migrations/001_init.sql
@@ -1,0 +1,40 @@
+create table if not exists tenants (
+  id text primary key,
+  name text not null,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists users (
+  id text primary key,
+  email text not null unique,
+  password_hash text not null,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists tenant_users (
+  tenant_id text not null references tenants(id) on delete cascade,
+  user_id text not null references users(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  primary key (tenant_id, user_id)
+);
+
+create table if not exists user_roles (
+  tenant_id text not null references tenants(id) on delete cascade,
+  user_id text not null references users(id) on delete cascade,
+  role text not null,
+  created_at timestamptz not null default now(),
+  primary key (tenant_id, user_id, role)
+);
+
+create table if not exists refresh_tokens (
+  token_hash text primary key,
+  user_id text not null references users(id) on delete cascade,
+  tenant_id text not null references tenants(id) on delete cascade,
+  expires_at timestamptz not null,
+  revoked_at timestamptz,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_refresh_tokens_user_tenant on refresh_tokens(user_id, tenant_id);
+create index if not exists idx_refresh_tokens_expires on refresh_tokens(expires_at);
+create index if not exists idx_user_roles_tenant_user on user_roles(tenant_id, user_id);


### PR DESCRIPTION
### Motivation

- Provide a ready-to-use, open-source style Go starter for a multi-tenant auth platform with two microservices (`auth-api` + `admin-api`) and a shared `modules/common-go` library. 
- Make local development and deployment trivial via `docker compose`, scripted migrations, and a smoke test so the project can be evaluated end-to-end from day one.

### Description

- Added full repository scaffold under `auth-platform-template/` including governance files (`README.md`, `LICENSE`, `SECURITY.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `CHANGELOG.md`) and workspace (`go.work`).
- Implemented `modules/common-go` shared module with config helpers, PostgreSQL (`pkg/db/pgsql`), Redis (`pkg/cache/redis`), JWT helpers (`pkg/auth/jwt`), envelope response (`pkg/httpx/resp`), `AppError` normalization (`pkg/httpx/apperr`), error codes (`pkg/httpx/errcode`) and Gin middleware (`pkg/httpx/ginmid`) for RequestID, Logger, CORS, AuthN, RateLimit, ErrorHandler and `Wrap` adapter.
- Implemented `services/auth-api` (port `8080`) with handlers for `healthz`, `bootstrap`, `register`, `login`, `refresh`, `logout`, refresh-token hashing/rotation, bcrypt password hashing, DB migrations (`migrations/001_init.sql`), and a multi-stage Dockerfile that uses the workspace to build.
- Implemented `services/admin-api` (port `8081`) with AuthN protection, tenant-match middleware, Casbin file-based RBAC (policy + model under `internal/rbac`), endpoints `healthz`, `GET /api/v1/admin/tenants/:tenantId/me/roles`, and `POST /api/v1/admin/tenants/:tenantId/users/:userId/roles/:role`, and a multi-stage Dockerfile copying the RBAC files into the runtime image.
- Added deployment and developer tooling: `deploy/docker-compose.yml`, `scripts/migrate.sh` (executes migration inside Postgres container), `scripts/seed.sh`, `scripts/smoke.sh` (bootstrap + admin me call using `python3` to parse envelope), examples (`examples/http/*.http`, `examples/postman/collection.json`), `Makefile` targets (`up`, `down`, `migrate`, `init`, `smoke`, `test`) and GitHub Actions CI workflow (`.github/workflows/ci.yml`) that runs migration and `go test` in CI using a local psql client.

### Testing

- Verified shell scripts and JSON format: ran `bash -n scripts/migrate.sh scripts/smoke.sh scripts/seed.sh` and `python3 -m json.tool examples/postman/collection.json`, both succeeded.
- Performed static checks: ran `gofmt -w` across Go sources and created `go.work` to wire modules; these formatting changes were included in the scaffold.
- Attempted to run `go mod tidy` / `go test ./...` locally, but dependency fetch failed due to network/proxy restrictions in this environment (Go proxy/GitHub returns 403), so full test execution could not complete here.
- Docker-based validation (`docker compose`) could not be executed in this environment because `docker` is not available; `scripts/migrate.sh` and `scripts/smoke.sh` are written to run against the compose services and were syntax-checked.

Files of note: `modules/common-go/*`, `services/auth-api/*`, `services/admin-api/*`, `deploy/docker-compose.yml`, `scripts/{migrate.sh,smoke.sh,seed.sh}`, `examples/postman/collection.json`, `.github/workflows/ci.yml`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699501befa988333aa8de3f451c3d181)