### PR TITLE
feat: add Docker Compose GHCR deployment workflow with remote SSH, health checks and rollback

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,136 @@
+name: deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Deployment environment
+        required: true
+        default: production
+        type: choice
+        options:
+          - production
+          - staging
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: deploy-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'production' }}
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  APP_NAME: anvilkit-auth-template
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.meta_auth.outputs.version }}
+      image_owner: ${{ steps.prep.outputs.owner_lc }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare image owner
+        id: prep
+        run: echo "owner_lc=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate auth-api metadata
+        id: meta_auth
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ steps.prep.outputs.owner_lc }}/${{ env.APP_NAME }}-auth-api
+          tags: |
+            type=ref,event=tag
+            type=sha,prefix=sha-
+
+      - name: Build and push auth-api image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: services/auth-api/Dockerfile
+          push: true
+          tags: ${{ steps.meta_auth.outputs.tags }}
+          labels: ${{ steps.meta_auth.outputs.labels }}
+
+      - name: Generate admin-api metadata
+        id: meta_admin
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ steps.prep.outputs.owner_lc }}/${{ env.APP_NAME }}-admin-api
+          tags: |
+            type=ref,event=tag
+            type=sha,prefix=sha-
+
+      - name: Build and push admin-api image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: services/admin-api/Dockerfile
+          push: true
+          tags: ${{ steps.meta_admin.outputs.tags }}
+          labels: ${{ steps.meta_admin.outputs.labels }}
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'production' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure SSH key
+        run: |
+          install -m 700 -d ~/.ssh
+          printf '%s\n' '${{ secrets.DEPLOY_SSH_KEY }}' > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+
+      - name: Upload deployment assets
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+        run: |
+          port="${DEPLOY_PORT:-22}"
+          ssh -p "$port" -o StrictHostKeyChecking=accept-new "$DEPLOY_USER@$DEPLOY_HOST" \
+            "mkdir -p '$DEPLOY_PATH/deploy' '$DEPLOY_PATH/scripts' '$DEPLOY_PATH/services/auth-api/migrations'"
+
+          scp -P "$port" -o StrictHostKeyChecking=accept-new deploy/docker-compose.prod.yml \
+            "$DEPLOY_USER@$DEPLOY_HOST:$DEPLOY_PATH/deploy/docker-compose.prod.yml"
+          scp -P "$port" -o StrictHostKeyChecking=accept-new scripts/remote_deploy.sh \
+            "$DEPLOY_USER@$DEPLOY_HOST:$DEPLOY_PATH/scripts/remote_deploy.sh"
+          scp -P "$port" -o StrictHostKeyChecking=accept-new services/auth-api/migrations/001_init.sql \
+            "$DEPLOY_USER@$DEPLOY_HOST:$DEPLOY_PATH/services/auth-api/migrations/001_init.sql"
+
+      - name: Run remote deployment
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+          IMAGE_TAG: ${{ needs.build.outputs.image_tag }}
+          IMAGE_OWNER: ${{ needs.build.outputs.image_owner }}
+          USE_INTERNAL_DEPS: ${{ vars.USE_INTERNAL_DEPS }}
+        run: |
+          port="${DEPLOY_PORT:-22}"
+          deps="${USE_INTERNAL_DEPS:-true}"
+          ssh -p "$port" -o StrictHostKeyChecking=accept-new "$DEPLOY_USER@$DEPLOY_HOST" \
+            "chmod +x '$DEPLOY_PATH/scripts/remote_deploy.sh' && \
+             '$DEPLOY_PATH/scripts/remote_deploy.sh' '$DEPLOY_PATH' '$IMAGE_TAG' '$IMAGE_OWNER' '$deps'"

--- a/README.md
+++ b/README.md
@@ -29,3 +29,80 @@ make smoke
 - Docker Compose one-command bootstrap.
 
 See `docs/` for architecture and API details.
+
+## 部署指南（Docker Compose + GitHub Actions）
+
+本仓库新增了 `.github/workflows/deploy.yml`，用于将 `auth-api` 与 `admin-api` 镜像构建并推送到 GHCR，再通过 SSH 在目标 Linux 服务器上执行容器部署。
+
+### 1) 服务器准备
+
+1. 安装 Docker 与 Docker Compose Plugin（`docker compose version` 可用）。
+2. 创建部署目录（示例）：`/opt/anvilkit-auth-template`。
+3. 在部署目录准备生产环境变量文件：`/opt/anvilkit-auth-template/.env`，至少包含：
+   - `DB_DSN`
+   - `REDIS_ADDR`
+   - `JWT_SECRET`
+   - `CORS_ALLOW_ORIGINS`
+   - `CORS_ALLOW_CREDENTIALS`
+4. 如果 DB/Redis 走外部服务，`DB_DSN/REDIS_ADDR` 指向外部地址，并在 GitHub Environment Variables 中设置 `USE_INTERNAL_DEPS=false`。
+5. 确保服务器可拉取 GHCR 镜像（镜像私有时，请预先 `docker login ghcr.io`）。
+
+> 说明：生产部署使用 `deploy/docker-compose.prod.yml`，其中包含 `migrate` 一次性迁移服务；部署时会先执行迁移，再启动 API 容器。
+
+### 2) GitHub Environments 与 Secrets 配置
+
+建议在 GitHub 仓库中创建 Environment（至少 `production`，可选 `staging`），并在每个 Environment 下配置：
+
+必需 Secrets：
+- `DEPLOY_SSH_KEY`：部署机私钥（建议专用 deploy key）
+- `DEPLOY_HOST`：服务器地址
+- `DEPLOY_USER`：SSH 用户
+- `DEPLOY_PATH`：远程部署目录（如 `/opt/anvilkit-auth-template`）
+- `DEPLOY_PORT`：可选，默认 22
+
+可选 Variables：
+- `USE_INTERNAL_DEPS`：`true`（默认，启动 compose 内 pg/redis）或 `false`（使用外部 DB/Redis）
+
+### 3) 触发部署
+
+支持两种触发方式：
+- `workflow_dispatch` 手动触发（默认，支持选择 `production/staging`）
+- 推送版本 tag（`v*`）触发自动部署（默认走 `production` environment）
+
+部署流程：
+1. 在 CI 构建并推送镜像：
+   - `ghcr.io/<owner>/anvilkit-auth-template-auth-api:<tag>`
+   - `ghcr.io/<owner>/anvilkit-auth-template-admin-api:<tag>`
+2. 上传 `docker-compose.prod.yml`、`remote_deploy.sh`、迁移 SQL 到服务器。
+3. 远程执行：
+   - `docker compose run --rm migrate`
+   - `docker compose pull && docker compose up -d`
+4. 健康检查：
+   - `curl -fsS http://127.0.0.1:8080/healthz`
+   - `curl -fsS http://127.0.0.1:8081/healthz`
+5. 健康检查失败自动回滚到上一版本 tag。
+
+### 4) 回滚机制
+
+远程脚本会在 `${DEPLOY_PATH}/.deploy_state` 维护：
+- `current_tag`
+- `prev_tag`
+
+当部署失败或健康检查失败时，脚本自动尝试回滚到 `prev_tag/current_tag` 并重新拉起服务。
+
+### 5) 可观测性与排障
+
+常用命令（在服务器部署目录执行）：
+
+```bash
+docker compose -f deploy/docker-compose.prod.yml --env-file .env ps
+docker compose -f deploy/docker-compose.prod.yml --env-file .env logs -f auth-api
+docker compose -f deploy/docker-compose.prod.yml --env-file .env logs -f admin-api
+curl -fsS http://127.0.0.1:8080/healthz
+curl -fsS http://127.0.0.1:8081/healthz
+```
+
+常见问题：
+- **拉取镜像失败（401/403）**：检查服务器是否已登录 GHCR 或镜像是否公开。
+- **迁移失败**：检查 `.env` 中 `DB_DSN` 连通性与权限；确认目标库可执行 SQL。
+- **健康检查失败**：查看 `auth-api/admin-api` 日志，确认依赖（DB/Redis、JWT_SECRET、CORS）配置完整。

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -1,0 +1,84 @@
+services:
+  pg:
+    image: postgres:16
+    profiles: ["with-deps"]
+    restart: unless-stopped
+    environment:
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-auth}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-auth}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    mem_limit: 512m
+
+  redis:
+    image: redis:7
+    profiles: ["with-deps"]
+    restart: unless-stopped
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - redisdata:/data
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    mem_limit: 256m
+
+  migrate:
+    image: postgres:16
+    restart: "no"
+    env_file:
+      - .env
+    volumes:
+      - ./services/auth-api/migrations:/migrations:ro
+    entrypoint:
+      - /bin/sh
+      - -ec
+      - |
+        echo "Running DB migration..."
+        psql "$DB_DSN" -v ON_ERROR_STOP=1 -f /migrations/001_init.sql
+        echo "DB migration completed."
+
+  auth-api:
+    image: ghcr.io/${IMAGE_OWNER}/anvilkit-auth-template-auth-api:${IMAGE_TAG}
+    restart: unless-stopped
+    env_file:
+      - .env
+    ports:
+      - "8080:8080"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8080/healthz >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 10
+      start_period: 20s
+    mem_limit: 512m
+
+  admin-api:
+    image: ghcr.io/${IMAGE_OWNER}/anvilkit-auth-template-admin-api:${IMAGE_TAG}
+    restart: unless-stopped
+    env_file:
+      - .env
+    ports:
+      - "8081:8081"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8081/healthz >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 10
+      start_period: 20s
+    mem_limit: 512m
+
+volumes:
+  pgdata:
+  redisdata:

--- a/scripts/remote_deploy.sh
+++ b/scripts/remote_deploy.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 3 ]]; then
+  echo "usage: $0 <deploy_path> <deploy_tag> <image_owner> [use_internal_deps:true|false]" >&2
+  exit 1
+fi
+
+DEPLOY_PATH="$1"
+DEPLOY_TAG="$2"
+IMAGE_OWNER="$3"
+USE_INTERNAL_DEPS="${4:-true}"
+
+COMPOSE_FILE="deploy/docker-compose.prod.yml"
+STATE_FILE=".deploy_state"
+ENV_FILE=".env"
+
+mkdir -p "$DEPLOY_PATH"
+cd "$DEPLOY_PATH"
+
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+  echo "missing $COMPOSE_FILE in $DEPLOY_PATH" >&2
+  exit 1
+fi
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "missing $ENV_FILE in $DEPLOY_PATH; please create it with production secrets" >&2
+  exit 1
+fi
+
+current_tag=""
+prev_tag=""
+if [[ -f "$STATE_FILE" ]]; then
+  # shellcheck disable=SC1090
+  source "$STATE_FILE"
+  current_tag="${current_tag:-}"
+  prev_tag="${prev_tag:-}"
+fi
+
+rollback_tag="${current_tag:-$prev_tag}"
+
+echo "Deploying image tag: $DEPLOY_TAG"
+echo "Current tag: ${current_tag:-<none>}"
+echo "Previous tag: ${prev_tag:-<none>}"
+
+export IMAGE_OWNER
+export IMAGE_TAG="$DEPLOY_TAG"
+
+compose_cmd=(docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE")
+if [[ "$USE_INTERNAL_DEPS" == "true" ]]; then
+  compose_cmd+=(--profile with-deps)
+fi
+
+"${compose_cmd[@]}" pull auth-api admin-api
+"${compose_cmd[@]}" run --rm migrate
+"${compose_cmd[@]}" up -d auth-api admin-api
+
+healthcheck() {
+  curl -fsS http://127.0.0.1:8080/healthz >/dev/null
+  curl -fsS http://127.0.0.1:8081/healthz >/dev/null
+}
+
+if healthcheck; then
+  echo "Health checks passed."
+  {
+    echo "current_tag=$DEPLOY_TAG"
+    echo "prev_tag=${current_tag:-$prev_tag}"
+  } > "$STATE_FILE"
+  echo "Deployment state updated in $STATE_FILE"
+  exit 0
+fi
+
+echo "Health checks failed, starting rollback..." >&2
+if [[ -z "$rollback_tag" ]]; then
+  echo "No rollback tag available." >&2
+  exit 1
+fi
+
+export IMAGE_TAG="$rollback_tag"
+"${compose_cmd[@]}" pull auth-api admin-api
+"${compose_cmd[@]}" up -d auth-api admin-api
+
+if healthcheck; then
+  echo "Rollback succeeded to tag: $rollback_tag"
+  exit 1
+fi
+
+echo "Rollback failed. Manual intervention required." >&2
+exit 1


### PR DESCRIPTION
### Motivation
- Provide a secure, observable, and rollback-capable deployment path to push `auth-api` and `admin-api` to a specified Linux server running Docker/Compose. 
- Keep existing CI (test/lint workflows) untouched while adding an opt-in `workflow_dispatch` / tag-triggered release flow that targets `production`/`staging` environments. 
- Ensure migrations are executed safely and that secrets remain on the server, not printed by the workflow.

### Description
- Add `.github/workflows/deploy.yml` which builds and pushes `auth-api` and `admin-api` images to GHCR using `docker/metadata-action` and `docker/build-push-action`, logs into GHCR securely, and uploads deployment assets over SSH to the target host. 
- Add `deploy/docker-compose.prod.yml` which pulls GHCR images (no remote build), provides a one-shot `migrate` service to run DB migrations, includes service `healthcheck`s, restart policy, resource limits, and a `with-deps` profile to optionally run internal `pg`/`redis`. 
- Add `scripts/remote_deploy.sh` (strict `set -euo pipefail`) which executes `docker compose pull`, runs the `migrate` job, brings up the APIs, validates both `/healthz` endpoints, and on failure automatically rolls back to the previous image tag using a persisted `${DEPLOY_PATH}/.deploy_state`. 
- Update `README.md` with a “部署指南” covering server prep, required GitHub Environment secrets (`DEPLOY_SSH_KEY`, `DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_PATH`, optional `DEPLOY_PORT`), how to trigger deployments, rollback semantics, and basic log/healthcheck commands.

### Testing
- Ran a syntax check on the remote script with `bash -n scripts/remote_deploy.sh`, which succeeded. 
- Attempted to validate the new YAML files via a small Python YAML loader but the environment lacked `PyYAML`, so automated YAML validation was not completed. 
- Attempted `docker compose` validation of `deploy/docker-compose.prod.yml` with `--env-file .env.example`, but the runner environment does not have the Docker CLI installed so compose validation could not be completed. 
- Manual inspections and local checks confirmed the workflow and scripts follow the requested secure SSH, GHCR, migration, healthcheck, and rollback design.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69951c3596508333b8d05cae79623e4b)