### PR TITLE
Fix remote deploy: pin compose project-directory and unify .env location

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -243,6 +243,9 @@ jobs:
             fi
           fi
 
+          ssh -p "$port" -o StrictHostKeyChecking=accept-new "$DEPLOY_USER@$DEPLOY_HOST" \
+            "test -f '$DEPLOY_PATH/.env' && echo 'Verified env file path: $DEPLOY_PATH/.env'"
+
       - name: Upload deployment assets
         env:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -32,12 +32,12 @@ services:
     image: postgres:16
     restart: "no"
     env_file:
-      - ../.env
+      - .env
     depends_on:
       pg:
         condition: service_healthy
     volumes:
-      - ./migrations:/migrations:ro
+      - ../migrations:/migrations:ro
     entrypoint:
       - /bin/sh
       - -ec
@@ -50,7 +50,7 @@ services:
     image: ghcr.io/${IMAGE_OWNER}/anvilkit-auth-template-auth-api:${IMAGE_TAG}
     restart: unless-stopped
     env_file:
-      - ../.env
+      - .env
     depends_on:
       pg:
         condition: service_healthy
@@ -70,7 +70,7 @@ services:
     image: ghcr.io/${IMAGE_OWNER}/anvilkit-auth-template-admin-api:${IMAGE_TAG}
     restart: unless-stopped
     env_file:
-      - ../.env
+      - .env
     depends_on:
       pg:
         condition: service_healthy

--- a/scripts/remote_deploy.sh
+++ b/scripts/remote_deploy.sh
@@ -16,6 +16,7 @@ GHCR_TOKEN="${GHCR_TOKEN:-}"
 COMPOSE_FILE="$DEPLOY_PATH/deploy/docker-compose.prod.yml"
 STATE_FILE="$DEPLOY_PATH/.deploy_state"
 ENV_FILE="$DEPLOY_PATH/.env"
+PROJECT_DIRECTORY="$DEPLOY_PATH"
 
 mkdir -p "$DEPLOY_PATH"
 
@@ -70,7 +71,14 @@ echo "USE_INTERNAL_DEPS: $USE_INTERNAL_DEPS"
 export IMAGE_OWNER
 export IMAGE_TAG="$DEPLOY_TAG"
 
-compose_cmd=(docker compose --project-directory "$DEPLOY_PATH" --env-file "$ENV_FILE" -f "$COMPOSE_FILE")
+compose_cmd=(docker compose --project-directory "$PROJECT_DIRECTORY" --env-file "$ENV_FILE" -f "$COMPOSE_FILE")
+
+echo "Compose diagnostics:"
+echo "  pwd: $(pwd)"
+echo "  DEPLOY_PATH: $DEPLOY_PATH"
+echo "  project-directory: $PROJECT_DIRECTORY"
+echo "  compose file: $COMPOSE_FILE"
+echo "  env file path: $ENV_FILE"
 
 migration_file="$DEPLOY_PATH/migrations/001_init.sql"
 if [[ ! -f "$migration_file" ]]; then


### PR DESCRIPTION
### Motivation
- Root cause: `deploy/docker-compose.prod.yml` referenced `../.env`, which resolves relative to the compose project directory and caused compose to look up `/home/<user>/.env` when the project-directory drifted; log showed `env file /home/***/.env not found` as evidence and the compose file contained `- ../.env`.
- Goal: make the env file location deterministic at `$DEPLOY_PATH/.env`, ensure first-deploy writes that file, and add diagnostics to prevent future directory-drift issues.

### Description
- Updated `scripts/remote_deploy.sh` to centralize `PROJECT_DIRECTORY="$DEPLOY_PATH"`, pin all `docker compose` invocations with `--project-directory "$PROJECT_DIRECTORY" --env-file "$ENV_FILE" -f "$COMPOSE_FILE"`, and print non-secret diagnostics (`pwd`, `DEPLOY_PATH`, `project-directory`, `compose file`, `env file path`).
- Changed `deploy/docker-compose.prod.yml` `env_file` entries from `../.env` to `.env` so the compose file uses the project directory's `.env` (i.e. `$DEPLOY_PATH/.env`), and adjusted the migrate volume to mount `../migrations` so uploaded `$DEPLOY_PATH/migrations/001_init.sql` is found.
- Touched `.github/workflows/deploy.yml` to explicitly verify the remote `$DEPLOY_PATH/.env` after copying (adds a verification SSH check and readable confirmation), keeping the existing step that creates/uploads `.env` as `.env` at `$DEPLOY_PATH`.
- Did not change business logic or secrets handling; only normalized paths and added diagnostics.

### Testing
- `bash -n scripts/remote_deploy.sh` succeeded (syntax check passed).
- Attempted `docker compose --env-file .env.example -f deploy/docker-compose.prod.yml config` and `docker build -f services/auth-api/Dockerfile .` / `docker build -f services/admin-api/Dockerfile .`, but these failed in this environment because `docker` is not installed (automated checks could not run here).
- Verified changes via local file diffs and committed the patch (`git` operations executed successfully in CI run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69957a032e8c83339324059620b682c0)