### PR TITLE
fix(ci): pin docker compose project-directory to repo root for config validation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,7 +91,7 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
         run: |
           cp .env.example .env
-          docker compose --env-file .env.example -f deploy/docker-compose.prod.yml config > /dev/null
+          docker compose --project-directory . --env-file .env -f deploy/docker-compose.prod.yml config > /dev/null
           rm -f .env
 
       - name: Build and push auth-api image


### PR DESCRIPTION
### Motivation
- The compose validation step used an unpinned working base so `env_file: .env` in `deploy/docker-compose.prod.yml` could resolve to `deploy/.env` during CI, causing `deploy/.env not found` even though the repo root `.env` was created by the workflow (root cause: missing `--project-directory` in the workflow compose command). 

### Description
- Updated `.github/workflows/deploy.yml` to run `docker compose --project-directory . --env-file .env -f deploy/docker-compose.prod.yml config > /dev/null` after creating a temporary root `.env`, leaving `deploy/docker-compose.prod.yml` and remote deploy behavior unchanged. 

### Testing
- Ran `cp .env.example .env` successfully in the workspace. 
- Attempted `docker compose --project-directory . --env-file .env -f deploy/docker-compose.prod.yml config > /dev/null` but the local execution environment lacked Docker (`docker: command not found`); in CI (with Docker available) the pinned command should prevent lookup of `deploy/.env` and pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69957c6967c08333894dc6f540699160)