### PR TITLE
feat(auth-api): unify auth config and add password & refresh-token utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,36 @@ make smoke
 
 See `docs/` for architecture and API details.
 
+## Auth 配置
+
+`auth-api` 启动时会从环境变量加载统一的认证配置（缺失关键项会直接报错并退出，不会打印敏感值）。
+
+| 变量 | 是否必填 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `JWT_ISSUER` | 是 | - | JWT `iss`（发行者） |
+| `JWT_AUDIENCE` | 是 | - | JWT `aud`（受众） |
+| `JWT_SECRET` | 是 | - | JWT 签名密钥（不要提交真实值） |
+| `ACCESS_TTL_MIN` | 否 | `15` | Access Token 过期分钟数 |
+| `REFRESH_TTL_HOURS` | 否 | `168` | Refresh Token 过期小时数（默认 7 天） |
+| `PASSWORD_MIN_LEN` | 否 | `8` | 密码最小长度策略 |
+| `BCRYPT_COST` | 否 | `12` | bcrypt 计算成本（4-31） |
+| `LOGIN_FAIL_LIMIT` | 否 | `5` | 登录失败限流阈值 |
+| `LOGIN_FAIL_WINDOW_MIN` | 否 | `10` | 登录失败限流统计窗口（分钟） |
+
+示例（开发环境）：
+
+```bash
+export JWT_ISSUER=anvilkit-auth
+export JWT_AUDIENCE=anvilkit-clients
+export JWT_SECRET=dev-secret-change-me
+export ACCESS_TTL_MIN=15
+export REFRESH_TTL_HOURS=168
+export PASSWORD_MIN_LEN=8
+export BCRYPT_COST=12
+export LOGIN_FAIL_LIMIT=5
+export LOGIN_FAIL_WINDOW_MIN=10
+```
+
 ## 部署指南（Docker Compose + GitHub Actions）
 
 本仓库新增了 `.github/workflows/deploy.yml`，用于将 `auth-api` 与 `admin-api` 镜像构建并推送到 GHCR，再通过 SSH 在目标 Linux 服务器上执行容器部署。

--- a/services/auth-api/cmd/auth-api/main.go
+++ b/services/auth-api/cmd/auth-api/main.go
@@ -11,6 +11,7 @@ import (
 	"anvilkit-auth-template/modules/common-go/pkg/cfg"
 	"anvilkit-auth-template/modules/common-go/pkg/db/pgsql"
 	"anvilkit-auth-template/modules/common-go/pkg/httpx/ginmid"
+	"anvilkit-auth-template/services/auth-api/internal/config"
 	"anvilkit-auth-template/services/auth-api/internal/handler"
 	"anvilkit-auth-template/services/auth-api/internal/store"
 )
@@ -25,12 +26,16 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	authCfg, err := config.LoadAuthConfigFromEnv()
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	h := &handler.Handler{
 		Store:      &store.Store{DB: db},
-		JWTSecret:  cfg.GetString("JWT_SECRET", "dev-secret-change-me"),
-		AccessTTL:  time.Duration(cfg.GetInt("ACCESS_TTL_MIN", 15)) * time.Minute,
-		RefreshTTL: time.Duration(cfg.GetInt("REFRESH_TTL_HOURS", 168)) * time.Hour,
+		JWTSecret:  authCfg.JWTSecret,
+		AccessTTL:  authCfg.AccessTTL,
+		RefreshTTL: authCfg.RefreshTTL,
 	}
 
 	r := gin.New()

--- a/services/auth-api/internal/auth/crypto/password.go
+++ b/services/auth-api/internal/auth/crypto/password.go
@@ -1,0 +1,26 @@
+package crypto
+
+import (
+	"errors"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+func HashPassword(password string, cost int) (string, error) {
+	if cost == 0 {
+		cost = bcrypt.DefaultCost
+	}
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), cost)
+	if err != nil {
+		return "", err
+	}
+	return string(hash), nil
+}
+
+func VerifyPassword(hash, password string) error {
+	err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
+	if errors.Is(err, bcrypt.ErrMismatchedHashAndPassword) {
+		return bcrypt.ErrMismatchedHashAndPassword
+	}
+	return err
+}

--- a/services/auth-api/internal/auth/crypto/password_test.go
+++ b/services/auth-api/internal/auth/crypto/password_test.go
@@ -1,0 +1,28 @@
+package crypto
+
+import (
+	"errors"
+	"testing"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+func TestHashAndVerifyPassword(t *testing.T) {
+	hash, err := HashPassword("Passw0rd!", bcrypt.MinCost)
+	if err != nil {
+		t.Fatalf("HashPassword() error = %v", err)
+	}
+	if err := VerifyPassword(hash, "Passw0rd!"); err != nil {
+		t.Fatalf("VerifyPassword() error = %v", err)
+	}
+}
+
+func TestVerifyPasswordWrongPassword(t *testing.T) {
+	hash, err := HashPassword("Passw0rd!", bcrypt.MinCost)
+	if err != nil {
+		t.Fatalf("HashPassword() error = %v", err)
+	}
+	if err := VerifyPassword(hash, "wrong-password"); !errors.Is(err, bcrypt.ErrMismatchedHashAndPassword) {
+		t.Fatalf("VerifyPassword() error = %v, want %v", err, bcrypt.ErrMismatchedHashAndPassword)
+	}
+}

--- a/services/auth-api/internal/auth/token/refresh.go
+++ b/services/auth-api/internal/auth/token/refresh.go
@@ -1,0 +1,41 @@
+package token
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+const defaultRefreshTokenBytes = 32
+
+func GenRefreshToken(nBytes int) (string, error) {
+	if nBytes <= 0 {
+		nBytes = defaultRefreshTokenBytes
+	}
+	buf := make([]byte, nBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+func HashRefreshToken(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}
+
+func ValidateRefreshTokenFormat(token string) error {
+	if strings.TrimSpace(token) == "" {
+		return fmt.Errorf("refresh token is required")
+	}
+	if strings.ContainsAny(token, "+/=") {
+		return fmt.Errorf("refresh token must be base64url without padding")
+	}
+	if _, err := base64.RawURLEncoding.DecodeString(token); err != nil {
+		return fmt.Errorf("refresh token must be valid base64url")
+	}
+	return nil
+}

--- a/services/auth-api/internal/auth/token/refresh_test.go
+++ b/services/auth-api/internal/auth/token/refresh_test.go
@@ -1,0 +1,32 @@
+package token
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestGenRefreshToken(t *testing.T) {
+	token, err := GenRefreshToken(32)
+	if err != nil {
+		t.Fatalf("GenRefreshToken() error = %v", err)
+	}
+	if token == "" {
+		t.Fatal("GenRefreshToken() token is empty")
+	}
+	if len(token) < 40 {
+		t.Fatalf("GenRefreshToken() token length = %d, want >= 40", len(token))
+	}
+	base64URLPattern := regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+	if !base64URLPattern.MatchString(token) {
+		t.Fatalf("GenRefreshToken() token = %q, want base64url characters only", token)
+	}
+}
+
+func TestHashRefreshTokenStable(t *testing.T) {
+	const input = "example-refresh-token"
+	h1 := HashRefreshToken(input)
+	h2 := HashRefreshToken(input)
+	if h1 != h2 {
+		t.Fatalf("HashRefreshToken() mismatch: %q != %q", h1, h2)
+	}
+}

--- a/services/auth-api/internal/config/auth.go
+++ b/services/auth-api/internal/config/auth.go
@@ -1,0 +1,100 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	defaultAccessTTLMin     = 15
+	defaultRefreshTTLHours  = 168
+	defaultPasswordMinLen   = 8
+	defaultBcryptCost       = 12
+	defaultLoginFailLimit   = 5
+	defaultLoginFailWindowM = 10
+)
+
+type AuthConfig struct {
+	JWTIssuer       string
+	JWTAudience     string
+	JWTSecret       string
+	AccessTTL       time.Duration
+	RefreshTTL      time.Duration
+	PasswordMinLen  int
+	BcryptCost      int
+	LoginFailLimit  int
+	LoginFailWindow time.Duration
+}
+
+func LoadAuthConfigFromEnv() (AuthConfig, error) {
+	issuer := strings.TrimSpace(os.Getenv("JWT_ISSUER"))
+	if issuer == "" {
+		return AuthConfig{}, fmt.Errorf("JWT_ISSUER is required")
+	}
+	audience := strings.TrimSpace(os.Getenv("JWT_AUDIENCE"))
+	if audience == "" {
+		return AuthConfig{}, fmt.Errorf("JWT_AUDIENCE is required")
+	}
+	secret := strings.TrimSpace(os.Getenv("JWT_SECRET"))
+	if secret == "" {
+		return AuthConfig{}, fmt.Errorf("JWT_SECRET is required")
+	}
+
+	accessTTLMin, err := getPositiveIntFromEnv("ACCESS_TTL_MIN", defaultAccessTTLMin)
+	if err != nil {
+		return AuthConfig{}, err
+	}
+	refreshTTLHours, err := getPositiveIntFromEnv("REFRESH_TTL_HOURS", defaultRefreshTTLHours)
+	if err != nil {
+		return AuthConfig{}, err
+	}
+	passwordMinLen, err := getPositiveIntFromEnv("PASSWORD_MIN_LEN", defaultPasswordMinLen)
+	if err != nil {
+		return AuthConfig{}, err
+	}
+	bcryptCost, err := getPositiveIntFromEnv("BCRYPT_COST", defaultBcryptCost)
+	if err != nil {
+		return AuthConfig{}, err
+	}
+	if bcryptCost < 4 || bcryptCost > 31 {
+		return AuthConfig{}, fmt.Errorf("BCRYPT_COST must be between 4 and 31")
+	}
+	loginFailLimit, err := getPositiveIntFromEnv("LOGIN_FAIL_LIMIT", defaultLoginFailLimit)
+	if err != nil {
+		return AuthConfig{}, err
+	}
+	loginFailWindowMin, err := getPositiveIntFromEnv("LOGIN_FAIL_WINDOW_MIN", defaultLoginFailWindowM)
+	if err != nil {
+		return AuthConfig{}, err
+	}
+
+	return AuthConfig{
+		JWTIssuer:       issuer,
+		JWTAudience:     audience,
+		JWTSecret:       secret,
+		AccessTTL:       time.Duration(accessTTLMin) * time.Minute,
+		RefreshTTL:      time.Duration(refreshTTLHours) * time.Hour,
+		PasswordMinLen:  passwordMinLen,
+		BcryptCost:      bcryptCost,
+		LoginFailLimit:  loginFailLimit,
+		LoginFailWindow: time.Duration(loginFailWindowMin) * time.Minute,
+	}, nil
+}
+
+func getPositiveIntFromEnv(key string, def int) (int, error) {
+	raw := strings.TrimSpace(os.Getenv(key))
+	if raw == "" {
+		return def, nil
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, fmt.Errorf("%s must be a valid integer", key)
+	}
+	if value <= 0 {
+		return 0, fmt.Errorf("%s must be greater than 0", key)
+	}
+	return value, nil
+}

--- a/services/auth-api/internal/config/auth_test.go
+++ b/services/auth-api/internal/config/auth_test.go
@@ -1,0 +1,87 @@
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLoadAuthConfigFromEnvMissingRequired(t *testing.T) {
+	t.Setenv("JWT_ISSUER", "")
+	t.Setenv("JWT_AUDIENCE", "")
+	t.Setenv("JWT_SECRET", "")
+
+	_, err := LoadAuthConfigFromEnv()
+	if err == nil {
+		t.Fatal("LoadAuthConfigFromEnv() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "JWT_ISSUER") {
+		t.Fatalf("LoadAuthConfigFromEnv() error = %q, want mention JWT_ISSUER", err)
+	}
+}
+
+func TestLoadAuthConfigFromEnvInvalidNumber(t *testing.T) {
+	setRequiredAuthEnv(t)
+	t.Setenv("ACCESS_TTL_MIN", "abc")
+
+	_, err := LoadAuthConfigFromEnv()
+	if err == nil {
+		t.Fatal("LoadAuthConfigFromEnv() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "ACCESS_TTL_MIN") {
+		t.Fatalf("LoadAuthConfigFromEnv() error = %q, want mention ACCESS_TTL_MIN", err)
+	}
+}
+
+func TestLoadAuthConfigFromEnvInvalidTTLValue(t *testing.T) {
+	setRequiredAuthEnv(t)
+	t.Setenv("REFRESH_TTL_HOURS", "0")
+
+	_, err := LoadAuthConfigFromEnv()
+	if err == nil {
+		t.Fatal("LoadAuthConfigFromEnv() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "REFRESH_TTL_HOURS") {
+		t.Fatalf("LoadAuthConfigFromEnv() error = %q, want mention REFRESH_TTL_HOURS", err)
+	}
+}
+
+func TestLoadAuthConfigFromEnvSuccess(t *testing.T) {
+	setRequiredAuthEnv(t)
+	t.Setenv("ACCESS_TTL_MIN", "20")
+	t.Setenv("REFRESH_TTL_HOURS", "240")
+	t.Setenv("PASSWORD_MIN_LEN", "10")
+	t.Setenv("BCRYPT_COST", "13")
+	t.Setenv("LOGIN_FAIL_LIMIT", "7")
+	t.Setenv("LOGIN_FAIL_WINDOW_MIN", "30")
+
+	cfg, err := LoadAuthConfigFromEnv()
+	if err != nil {
+		t.Fatalf("LoadAuthConfigFromEnv() error = %v", err)
+	}
+	if cfg.AccessTTL != 20*time.Minute {
+		t.Fatalf("AccessTTL = %v, want %v", cfg.AccessTTL, 20*time.Minute)
+	}
+	if cfg.RefreshTTL != 240*time.Hour {
+		t.Fatalf("RefreshTTL = %v, want %v", cfg.RefreshTTL, 240*time.Hour)
+	}
+	if cfg.PasswordMinLen != 10 {
+		t.Fatalf("PasswordMinLen = %d, want 10", cfg.PasswordMinLen)
+	}
+	if cfg.BcryptCost != 13 {
+		t.Fatalf("BcryptCost = %d, want 13", cfg.BcryptCost)
+	}
+	if cfg.LoginFailLimit != 7 {
+		t.Fatalf("LoginFailLimit = %d, want 7", cfg.LoginFailLimit)
+	}
+	if cfg.LoginFailWindow != 30*time.Minute {
+		t.Fatalf("LoginFailWindow = %v, want %v", cfg.LoginFailWindow, 30*time.Minute)
+	}
+}
+
+func setRequiredAuthEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("JWT_ISSUER", "anvilkit-auth")
+	t.Setenv("JWT_AUDIENCE", "anvilkit-clients")
+	t.Setenv("JWT_SECRET", "test-secret-value")
+}


### PR DESCRIPTION
### Motivation
- 将认证相关配置集中到一个结构体并从环境变量加载，便于启动时 fail-fast 校验并在后续 `register/login/refresh` 中复用。  
- 提供可配置 bcrypt 密码工具与 refresh token（opaque + sha256 hash）工具，避免业务层重复实现并保证一致性和安全约束（不打印 secrets）。

### Description
- 新增 `AuthConfig` 与 `LoadAuthConfigFromEnv()`，放置在 `services/auth-api/internal/config/auth.go`，校验必填项 `JWT_ISSUER`/`JWT_AUDIENCE`/`JWT_SECRET`，解析数值 env 并将 TTL 转为 `time.Duration`，对非法值返回可读错误（不泄露敏感值）。
- 新增 bcrypt 密码工具 `HashPassword(password, cost)` 与 `VerifyPassword(hash, password)`，放在 `services/auth-api/internal/auth/crypto/password.go`，支持可配置 cost。
- 新增 refresh token 工具 `GenRefreshToken(nBytes)`（base64url 无 padding）、`HashRefreshToken(token)`（sha256 hex）与 `ValidateRefreshTokenFormat(token)`，放在 `services/auth-api/internal/auth/token/refresh.go`。 
- 在启动入口 `services/auth-api/cmd/auth-api/main.go` 接入配置加载并将 `JWTSecret/AccessTTL/RefreshTTL` 注入 handler，避免散落读取 env。 
- 新增单元测试覆盖核心工具：`services/auth-api/internal/config/auth_test.go`、`services/auth-api/internal/auth/crypto/password_test.go`、`services/auth-api/internal/auth/token/refresh_test.go`，并更新 `README.md` 增加 “Auth 配置” 章节列出新增 env 与示例。 

### Testing
- 运行 `go test ./services/auth-api/...`：所有新增包的单元测试通过（输出显示 `ok`，新建的 config/crypto/token 测试均已通过）。
- 运行 `go test ./...`：顶层测试也通过（新增单测不会导致失败）。
- 运行 `gofmt`：对新增文件已格式化。 
- 尝试运行 `golangci-lint run` 在此环境中报错为工具配置/版本不兼容（`unsupported version of the configuration`），该错误与本次代码变更无关，建议由 CI（仓库环境）运行 `golangci-lint` 来确认 lint 绿灯并在需要时调整 lint 配置。 

Note: 为满足 GitHub 自动关闭 Issue 的要求，请维护者在创建 PR 时将下方占位替换为真实 issue 编号（仓库本地环境未能解析远程 issue 列表）：

Closes #<issue_number>

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995a99f0e6c833389904b239778b051)