### PR TITLE
feat: add AuthN core migration and run all SQL migrations in deploy chain (Closes #18)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,10 @@ jobs:
           exit 1
 
       - name: Migrate database
-        run: psql "postgres://postgres:postgres@localhost:5432/auth?sslmode=disable" -f services/auth-api/migrations/001_init.sql
+        run: |
+          for file in $(find services/auth-api/migrations -maxdepth 1 -type f -name '*.sql' | sort); do
+            psql "postgres://postgres:postgres@localhost:5432/auth?sslmode=disable" -v ON_ERROR_STOP=1 -f "$file"
+          done
 
       - name: Run module tests
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -263,11 +263,11 @@ jobs:
             "$DEPLOY_USER@$DEPLOY_HOST:$DEPLOY_PATH/deploy/docker-compose.prod.yml"
           scp -P "$port" -o StrictHostKeyChecking=accept-new scripts/remote_deploy.sh \
             "$DEPLOY_USER@$DEPLOY_HOST:$DEPLOY_PATH/scripts/remote_deploy.sh"
-          scp -P "$port" -o StrictHostKeyChecking=accept-new services/auth-api/migrations/001_init.sql \
-            "$DEPLOY_USER@$DEPLOY_HOST:$DEPLOY_PATH/migrations/001_init.sql"
+          scp -P "$port" -o StrictHostKeyChecking=accept-new services/auth-api/migrations/*.sql \
+            "$DEPLOY_USER@$DEPLOY_HOST:$DEPLOY_PATH/migrations/"
 
           ssh -p "$port" -o StrictHostKeyChecking=accept-new "$DEPLOY_USER@$DEPLOY_HOST" \
-            "ls -la '$DEPLOY_PATH/migrations'"
+            "ls -la '$DEPLOY_PATH/migrations' && test -f '$DEPLOY_PATH/migrations/002_authn_core.sql'"
 
       - name: Run remote deployment
         env:

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -45,7 +45,10 @@ services:
       - -ec
       - |
         echo "Running DB migration..."
-        psql "$DB_DSN" -v ON_ERROR_STOP=1 -f /migrations/001_init.sql
+        for file in $(find /migrations -maxdepth 1 -type f -name '*.sql' | sort); do
+          echo "Applying migration: ${file}"
+          psql "$DB_DSN" -v ON_ERROR_STOP=1 -f "${file}"
+        done
         echo "DB migration completed."
 
   auth-api:

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-docker compose -f deploy/docker-compose.yml exec -T pg \
-  psql -U postgres -d auth < services/auth-api/migrations/001_init.sql
+for file in $(find services/auth-api/migrations -maxdepth 1 -type f -name '*.sql' | sort); do
+  docker compose -f deploy/docker-compose.yml exec -T pg \
+    psql -U postgres -d auth -v ON_ERROR_STOP=1 -f - < "$file"
+  echo "applied migration: $file"
+done
 
 echo "migrate ok"

--- a/scripts/remote_deploy.sh
+++ b/scripts/remote_deploy.sh
@@ -90,9 +90,9 @@ echo "  env_file: $ENV_FILE"
 echo "  MIGRATIONS_DIR: $MIGRATIONS_DIR"
 echo "  project_name: $COMPOSE_PROJECT_NAME"
 
-migration_file="$MIGRATIONS_DIR/001_init.sql"
+migration_file="$MIGRATIONS_DIR/002_authn_core.sql"
 if [[ ! -f "$migration_file" ]]; then
-  echo "missing migration file: $migration_file (workflow 未上传迁移文件)" >&2
+  echo "missing required migration file: $migration_file (workflow 未上传完整迁移文件)" >&2
   echo "Diagnostics: pwd" >&2
   pwd >&2
   echo "Diagnostics: ls -la $DEPLOY_PATH" >&2
@@ -102,8 +102,12 @@ if [[ ! -f "$migration_file" ]]; then
   exit 1
 fi
 
+if ! compgen -G "$MIGRATIONS_DIR/*.sql" >/dev/null; then
+  echo "no SQL migrations found under $MIGRATIONS_DIR" >&2
+  exit 1
+fi
+
 echo "Preflight checks..."
-test -f "$migration_file"
 "${compose_cmd[@]}" config >/dev/null
 
 echo "Resolved compose migrate volume config:"

--- a/services/auth-api/migrations/002_authn_core.sql
+++ b/services/auth-api/migrations/002_authn_core.sql
@@ -1,0 +1,49 @@
+-- M1-02: AuthN core schema (minimal account model + refresh rotation persistence)
+
+-- users table is introduced in 001_init.sql in this template.
+-- Keep migration idempotent and align legacy shape with AuthN requirements.
+alter table if exists users
+  alter column email drop not null;
+
+alter table if exists users
+  add column if not exists phone text,
+  add column if not exists status smallint not null default 1,
+  add column if not exists updated_at timestamptz not null default now();
+
+create unique index if not exists idx_users_phone_unique
+  on users(phone)
+  where phone is not null;
+
+-- Move password hash into dedicated credentials table.
+create table if not exists user_password_credentials (
+  user_id text primary key references users(id) on delete cascade,
+  password_hash text not null,
+  updated_at timestamptz not null default now()
+);
+
+insert into user_password_credentials (user_id, password_hash)
+select u.id, u.password_hash
+from users u
+where u.password_hash is not null
+  and not exists (
+    select 1
+    from user_password_credentials upc
+    where upc.user_id = u.id
+  );
+
+-- Persist refresh token rotation chain.
+create table if not exists refresh_sessions (
+  id text primary key,
+  user_id text not null references users(id) on delete cascade,
+  token_hash text not null unique,
+  user_agent text,
+  ip text,
+  expires_at timestamptz not null,
+  revoked_at timestamptz,
+  replaced_by text references refresh_sessions(id),
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_refresh_sessions_user_id on refresh_sessions(user_id);
+create index if not exists idx_refresh_sessions_expires_at on refresh_sessions(expires_at);
+create index if not exists idx_refresh_sessions_replaced_by on refresh_sessions(replaced_by);


### PR DESCRIPTION
## Summary
- Added `services/auth-api/migrations/002_authn_core.sql` for AuthN core schema:
  - aligned `users` to minimal account model (nullable `email`, `phone`, `status`, `updated_at`)
  - added `user_password_credentials` (FK to `users`, cascade delete)
  - added `refresh_sessions` with rotation fields `revoked_at`, `replaced_by`, unique `token_hash`, and indexes (`user_id`, `expires_at`, `replaced_by`)
- Updated migration execution mechanism to run **all** SQL files in lexical order instead of only `001_init.sql`:
  - `.github/workflows/ci.yml`
  - `deploy/docker-compose.prod.yml` (migrate service)
  - `scripts/migrate.sh`
- Updated deployment asset upload and remote preflight checks:
  - `.github/workflows/deploy.yml` now uploads `services/auth-api/migrations/*.sql`
  - `scripts/remote_deploy.sh` now verifies presence of `002_authn_core.sql` and checks `*.sql` exists

Closes #18

## Checklist (Issue #18)
- [x] 编写 migration（幂等：`IF NOT EXISTS`）
- [x] `refresh_sessions.token_hash` 设为 `UNIQUE`
- [x] `refresh_sessions` 支持 rotation 字段：`revoked_at`、`replaced_by`
- [x] 更新 migrate 资产上传/运行逻辑（生产链路可读到 002 并执行）
- [x] migration 可重复执行不报错（SQL 语句按幂等方式编写）
- [x] refresh session 可通过 `token_hash` 唯一定位（UNIQUE 约束）
- [x] 生产部署 migrate 能成功执行该 migration（migrate 改为遍历 `/migrations/*.sql`）

## Validation commands and results
> Note: this execution environment does not provide Docker CLI/daemon, so containerized runtime verification could not be executed here.

- `docker compose -f deploy/docker-compose.yml up -d pg`
  - Result: `bash: command not found: docker`
- `./scripts/migrate.sh`
  - Blocked by same Docker dependency in this environment
- Static validation completed by code inspection and config/migration-chain updates:
  - CI migration step now iterates all migration SQL files in order
  - prod compose migrate service now iterates all migration SQL files in order
  - deploy workflow uploads all migration SQL files and verifies `002_authn_core.sql` on remote
  - remote deploy script preflight now requires `002_authn_core.sql` and `*.sql` presence

## Changed files
- `.github/workflows/ci.yml`
- `.github/workflows/deploy.yml`
- `deploy/docker-compose.prod.yml`
- `scripts/migrate.sh`
- `scripts/remote_deploy.sh`
- `services/auth-api/migrations/002_authn_core.sql`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995ebfade90833396998275a2acd4a3)