### PR TITLE
Fix migrate compose shell-variable escaping and deterministic SQL execution

### DIFF
--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -44,16 +44,12 @@ services:
       - /bin/sh
       - -ec
       - |
+        set -euo pipefail
         echo "Running DB migration..."
         ls -la /migrations
-        set -- /migrations/*.sql
-        if [ ! -e "$1" ]; then
-          echo "No migration SQL files found under /migrations" >&2
-          exit 1
-        fi
-        for f in "$@"; do
-          echo "Applying migration: $f"
-          psql "$DB_DSN" -v ON_ERROR_STOP=1 -f "$f"
+        for f in $$(ls -1 /migrations/*.sql | sort); do
+          echo "Applying migration: $$f"
+          psql "$$DB_DSN" -v ON_ERROR_STOP=1 -f "$$f"
         done
         echo "DB migration completed."
 

--- a/scripts/remote_deploy.sh
+++ b/scripts/remote_deploy.sh
@@ -20,6 +20,10 @@ ENV_FILE="$DEPLOY_PATH/.env"
 PROJECT_DIRECTORY="$DEPLOY_PATH"
 MIGRATIONS_DIR="$DEPLOY_PATH/migrations"
 
+export DEPLOY_PATH
+export MIGRATIONS_DIR
+export IMAGE_OWNER
+
 mkdir -p "$DEPLOY_PATH"
 
 if [[ ! -f "$COMPOSE_FILE" ]]; then
@@ -75,12 +79,10 @@ echo "Current tag: ${current_tag:-<none>}"
 echo "Previous tag: ${prev_tag:-<none>}"
 echo "USE_INTERNAL_DEPS: $USE_INTERNAL_DEPS"
 
+IMAGE_TAG="$DEPLOY_TAG"
+export IMAGE_TAG
+
 compose_cmd=(
-  env
-  DEPLOY_PATH="$DEPLOY_PATH"
-  MIGRATIONS_DIR="$MIGRATIONS_DIR"
-  IMAGE_OWNER="$IMAGE_OWNER"
-  IMAGE_TAG="$DEPLOY_TAG"
   docker compose
   -p "$COMPOSE_PROJECT_NAME"
   --project-directory "$PROJECT_DIRECTORY"
@@ -208,12 +210,10 @@ if [[ -z "$rollback_tag" ]]; then
   exit 1
 fi
 
+IMAGE_TAG="$rollback_tag"
+export IMAGE_TAG
+
 compose_cmd=(
-  env
-  DEPLOY_PATH="$DEPLOY_PATH"
-  MIGRATIONS_DIR="$MIGRATIONS_DIR"
-  IMAGE_OWNER="$IMAGE_OWNER"
-  IMAGE_TAG="$rollback_tag"
   docker compose
   -p "$COMPOSE_PROJECT_NAME"
   --project-directory "$PROJECT_DIRECTORY"


### PR DESCRIPTION
## Summary
- Fixed `deploy/docker-compose.prod.yml` migrate entrypoint so shell variables are escaped for Docker Compose interpolation (`$$f`, `$$DB_DSN`).
- Updated migrate command to run all `/migrations/*.sql` files in sorted order with:
  - `set -euo pipefail`
  - `ls -la /migrations`
  - ordered loop execution and `ON_ERROR_STOP=1`
- Kept migrations mounted as a directory via `${MIGRATIONS_DIR}:/migrations:ro`.
- Updated `scripts/remote_deploy.sh` to explicitly export `DEPLOY_PATH`, `MIGRATIONS_DIR`, `IMAGE_OWNER`, and `IMAGE_TAG` before invoking `docker compose`.

## Root cause
Compose was interpreting shell-variable-like tokens in the YAML command block. Escaping with `$$` ensures Compose emits literal `$...` so expansion happens inside the container shell.

## Validation
- Attempted to run compose config and migrate checks in a temporary deploy path, but this execution environment lacks Docker CLI/daemon (`docker: command not found`).
- Static inspection confirms no unescaped `$f`/`${f}` remains in the migrate compose command and loop now runs deterministically over `/migrations/*.sql`.

## Changed files
- `deploy/docker-compose.prod.yml`
- `scripts/remote_deploy.sh`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995f7b0c73083339fe3d9403215792e)