### PR TITLE
feat(common-go): gin AuthN middleware — parse JWT, set uid, and tests

### DIFF
--- a/modules/common-go/pkg/httpx/ginmid/authn.go
+++ b/modules/common-go/pkg/httpx/ginmid/authn.go
@@ -14,18 +14,29 @@ func AuthN(secret, issuer, audience string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		raw := strings.TrimSpace(c.GetHeader("Authorization"))
 		if !strings.HasPrefix(raw, "Bearer ") {
-			_ = c.Error(apperr.Unauthorized(errors.New("missing_bearer")))
+			_ = c.Error(apperr.Unauthorized(errors.New("missing_bearer")).WithData(map[string]any{"reason": "missing_bearer"}))
 			c.Abort()
 			return
 		}
 		token := strings.TrimSpace(strings.TrimPrefix(raw, "Bearer "))
 		claims, err := ajwt.Parse(secret, issuer, audience, token)
 		if err != nil || claims.Typ != "access" {
-			_ = c.Error(apperr.Unauthorized(errors.New("invalid_access_token")))
+			_ = c.Error(apperr.Unauthorized(errors.New("invalid_access_token")).WithData(map[string]any{"reason": "invalid_access_token"}))
 			c.Abort()
 			return
 		}
-		c.Set("uid", claims.UID)
+
+		uid := claims.Subject
+		if uid == "" {
+			uid = claims.UID
+		}
+		if uid == "" {
+			_ = c.Error(apperr.Unauthorized(errors.New("missing_sub")).WithData(map[string]any{"reason": "missing_sub"}))
+			c.Abort()
+			return
+		}
+
+		c.Set("uid", uid)
 		c.Set("tid", claims.TID)
 		c.Next()
 	}

--- a/modules/common-go/pkg/httpx/ginmid/authn_test.go
+++ b/modules/common-go/pkg/httpx/ginmid/authn_test.go
@@ -1,0 +1,165 @@
+package ginmid
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	ajwt "anvilkit-auth-template/modules/common-go/pkg/auth/jwt"
+	"anvilkit-auth-template/modules/common-go/pkg/httpx/errcode"
+	"anvilkit-auth-template/modules/common-go/pkg/httpx/resp"
+)
+
+const (
+	testJWTSecret   = "test-secret"
+	testJWTIssuer   = "anvilkit-auth"
+	testJWTAudience = "anvilkit-clients"
+)
+
+type testEnvelope struct {
+	RequestID string          `json:"request_id"`
+	Code      int             `json:"code"`
+	Message   string          `json:"message"`
+	Data      json.RawMessage `json:"data"`
+}
+
+func TestAuthN_UnauthorizedScenarios(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name          string
+		authorization string
+		buildToken    func(t *testing.T) string
+	}{
+		{
+			name: "missing Authorization",
+		},
+		{
+			name:          "non bearer format",
+			authorization: "Basic abc",
+		},
+		{
+			name:          "invalid token",
+			authorization: "Bearer not-a-jwt",
+		},
+		{
+			name: "expired token",
+			buildToken: func(t *testing.T) string {
+				t.Helper()
+				token, err := ajwt.Sign(testJWTSecret, testJWTIssuer, testJWTAudience, "uid-expired", "", "access", -1*time.Minute)
+				if err != nil {
+					t.Fatalf("sign token: %v", err)
+				}
+				return token
+			},
+		},
+		{
+			name: "issuer mismatch",
+			buildToken: func(t *testing.T) string {
+				t.Helper()
+				token, err := ajwt.Sign(testJWTSecret, "another-issuer", testJWTAudience, "uid-issuer", "", "access", time.Minute)
+				if err != nil {
+					t.Fatalf("sign token: %v", err)
+				}
+				return token
+			},
+		},
+		{
+			name: "audience mismatch",
+			buildToken: func(t *testing.T) string {
+				t.Helper()
+				token, err := ajwt.Sign(testJWTSecret, testJWTIssuer, "another-audience", "uid-audience", "", "access", time.Minute)
+				if err != nil {
+					t.Fatalf("sign token: %v", err)
+				}
+				return token
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newAuthNTestRouter(t)
+			req, _ := http.NewRequest(http.MethodGet, "/protected", nil)
+			authorization := tt.authorization
+			if tt.buildToken != nil {
+				authorization = "Bearer " + tt.buildToken(t)
+			}
+			if authorization != "" {
+				req.Header.Set("Authorization", authorization)
+			}
+
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+
+			if w.Code != http.StatusUnauthorized {
+				t.Fatalf("status=%d want=%d body=%s", w.Code, http.StatusUnauthorized, w.Body.String())
+			}
+
+			var body testEnvelope
+			if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if body.Code != errcode.Unauthorized {
+				t.Fatalf("code=%d want=%d", body.Code, errcode.Unauthorized)
+			}
+			if body.Message != "unauthorized" {
+				t.Fatalf("message=%q want=unauthorized", body.Message)
+			}
+		})
+	}
+}
+
+func TestAuthN_SuccessSetsUIDInContext(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	token, err := ajwt.Sign(testJWTSecret, testJWTIssuer, testJWTAudience, "uid-ok", "tenant-ok", "access", time.Minute)
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+
+	r := newAuthNTestRouter(t)
+	req, _ := http.NewRequest(http.MethodGet, "/protected", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d want=%d body=%s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var body struct {
+		Code int `json:"code"`
+		Data struct {
+			UID string `json:"uid"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Code != 0 {
+		t.Fatalf("code=%d want=0", body.Code)
+	}
+	if body.Data.UID != "uid-ok" {
+		t.Fatalf("uid=%q want=uid-ok", body.Data.UID)
+	}
+}
+
+func newAuthNTestRouter(t *testing.T) *gin.Engine {
+	t.Helper()
+	r := gin.New()
+	r.Use(RequestID(), ErrorHandler())
+	r.GET("/protected", AuthN(testJWTSecret, testJWTIssuer, testJWTAudience), func(c *gin.Context) {
+		uid, ok := c.Get("uid")
+		if !ok {
+			t.Fatalf("uid should exist in context")
+		}
+		resp.OK(c, map[string]any{"uid": uid})
+	})
+	return r
+}


### PR DESCRIPTION
### Motivation
- 统一并强化服务端 JWT 验证与 Gin 中间件行为，确保所有服务（auth-api / admin-api）复用一致的 AuthN 实现并把用户标识写入请求上下文以便后续授权逻辑使用。 
- 遵循仓库现有 Envelope + AppError 风格，让中间件在失败时不直接写响应体，而是通过 `c.Error(...)+c.Abort()` 委托 `ginmid.ErrorHandler` 输出统一 Envelope。

### Description
- 实现/修改：加强 `modules/common-go/pkg/httpx/ginmid.AuthN`，行为如下：严格解析 `Authorization: Bearer <token>`，使用 `modules/common-go/pkg/auth/jwt.Parse`（HS256 + `WithIssuer` + `WithAudience`）校验签名/alg/iss/aud/exp/iat，认证成功后将 `uid` 写入 `c.Set("uid", <uid>)`（类型为 `string`，优先取 `sub` / `claims.Subject`，回退 `claims.UID`）；所有失败路径均使用 `c.Error(apperr.Unauthorized(...).WithData(...)) + c.Abort()`。
- 新增单元测试 `modules/common-go/pkg/httpx/ginmid/authn_test.go`，覆盖缺失 Authorization / 非 Bearer / 无效 token / 过期 / iss 不匹配 / aud 不匹配 / 成功 token 并能从 handler 读取到 `uid`。
- 保持现有风格：未引入新的响应格式，继续使用 `apperr` + `ginmid.ErrorHandler` -> `resp.Envelope`；`Logger` 中间件能读取并打印 `uid`。
- Closes #23

Issue #23 Checklist（逐条勾选并附验证方式/结果）
- [x] JWT claims 统一为 `iss/aud/sub(uid)/exp/iat`（签发逻辑已使用 `RegisteredClaims` 填充）。 验证方式/结果：检查 `modules/common-go/pkg/auth/jwt/jwt.go` 中 `Sign` 使用 `jwtv5.RegisteredClaims{Issuer, Audience, IssuedAt, ExpiresAt, Subject}`，结果符合。
- [x] 从 `Authorization: Bearer <token>` 解析 JWT。 验证方式/结果：`ginmid.AuthN` 仅接受 `Authorization` 且以 `Bearer ` 为前缀，测试覆盖缺失与非 Bearer 场景通过。
- [x] 认证成功将 `uid` 写入 `gin.Context`（主键统一 `uid`）。 验证方式/结果：`AuthN` 将 `claims.Subject` 或回退 `claims.UID` 写入 `c.Set("uid", ...)`，测试 `TestAuthN_SuccessSetsUIDInContext` 验证 handler 能读出并返回 `uid`。
- [x] middleware 不直接 `c.JSON`，改为 `c.Error + Abort`，由 `ErrorHandler` 输出统一 Envelope。 验证方式/结果：代码使用 `c.Error(apperr.Unauthorized(...)).Abort()`，测试中挂载 `ErrorHandler` 并断言返回 Envelope（`code=1002,message=unauthorized`）。
- [x] 失败场景统一为 unauthorized（缺失/格式错误/无效/过期/iss/aud 不匹配）。 验证方式/结果：新增测试 `TestAuthN_UnauthorizedScenarios` 覆盖所有失败类型并全部断言 401 + Envelope unauthorized。
- [x] 补齐 middleware 单元测试并覆盖必测清单 1~7。 验证方式/结果：新增 `authn_test.go`，运行 `go test`（modules/common-go）结果 `ok`。
- [x] auth-api/admin-api 均复用同一 `ginmid.AuthN`。 验证方式/结果：检查 `services/auth-api/cmd/auth-api/main.go` 与 `services/admin-api/cmd/admin-api/main.go`，两处均使用 `ginmid.AuthN(...)`。
- [x] Logger 可读取并打印 `uid`。 验证方式/结果：`modules/common-go/pkg/httpx/ginmid/logger.go` 中 `uid, _ := c.Get("uid")` 并 `log.Printf`，在成功认证后能打印 uid（测试中已确认上下文写入）。

### Testing
- 运行命令与结果（自动化测试）：
  - `go test ./... -count=1` (workdir=`modules/common-go`) — 成功 (`ok` for `pkg/httpx/ginmid` tests including new `authn_test.go`).
  - `go test ./... -count=1` (workdir=`services/admin-api`) — 成功 (无测试文件或通过)。
  - `go test ./... -count=1` (workdir=`services/auth-api`) — 部分测试失败因依赖 Postgres/Redis 未在本地运行（环境依赖导致连接被拒绝）；这是环境问题非本次改动引起，单元测试在 modules/common-go 模块全部通过。
  - `go test ./... -count=1` (repo root) — 没有顶层测试文件（返回正常）。
  - `golangci-lint run` — 报错：当前环境 golangci-lint 与仓库配置版本不兼容（`unsupported version of the configuration`），属于环境工具问题，与代码变更无关。

变更文件清单（主要）
- modified: `modules/common-go/pkg/httpx/ginmid/authn.go`
- added:    `modules/common-go/pkg/httpx/ginmid/authn_test.go`

关键实现要点
- uid 类型与 ctx key：`string`, key="uid"，优先 `claims.Subject`（sub），回退 `claims.UID`。
- JWT 验证策略：HS256 签名 + `jwtv5.WithIssuer(expected)` + `jwtv5.WithAudience(expected)` + 标准 registered claims 校验（exp/iat/sub）。

所有改动已格式化 (`gofmt`) 并提交。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998fd4bd8188333985c631101fcc252)