### PR TITLE
feat(auth): add tid claim support and switch_tenant endpoint

### DIFF
--- a/examples/postman/collection.json
+++ b/examples/postman/collection.json
@@ -178,6 +178,50 @@
       ]
     },
     {
+      "name": "switch_tenant",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{access_token}}"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\"tenant_id\": \"{{tenant_id}}\"}"
+        },
+        "url": {
+          "raw": "{{base_url_auth}}/v1/auth/switch_tenant",
+          "host": [
+            "{{base_url_auth}}"
+          ],
+          "path": [
+            "v1",
+            "auth",
+            "switch_tenant"
+          ]
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('status is 200', function () { pm.response.to.have.status(200); });",
+              "const json = pm.response.json();",
+              "pm.collectionVariables.set('access_token', json.data.access_token);"
+            ]
+          }
+        }
+      ]
+    },
+    {
       "name": "admin me roles",
       "request": {
         "method": "GET",

--- a/modules/common-go/pkg/auth/jwt/jwt.go
+++ b/modules/common-go/pkg/auth/jwt/jwt.go
@@ -32,6 +32,14 @@ func Sign(secret, issuer, audience, uid, tid, typ string, ttl time.Duration) (st
 	return token.SignedString([]byte(secret))
 }
 
+func SignAccessToken(secret, issuer, audience, uid string, tid *string, ttl time.Duration) (string, error) {
+	tenantID := ""
+	if tid != nil {
+		tenantID = *tid
+	}
+	return Sign(secret, issuer, audience, uid, tenantID, "access", ttl)
+}
+
 func Parse(secret, issuer, audience, tokenStr string) (*Claims, error) {
 	t, err := jwtv5.ParseWithClaims(tokenStr, &Claims{}, func(token *jwtv5.Token) (any, error) {
 		if token.Method != jwtv5.SigningMethodHS256 {

--- a/services/auth-api/cmd/auth-api/main.go
+++ b/services/auth-api/cmd/auth-api/main.go
@@ -62,6 +62,7 @@ func main() {
 	api.POST("/refresh", ginmid.Wrap(h.Refresh))
 	api.POST("/logout", ginmid.Wrap(h.Logout))
 	api.POST("/logout_all", ginmid.AuthN(h.JWTSecret, h.JWTIssuer, h.JWTAudience), ginmid.Wrap(h.LogoutAll))
+	api.POST("/switch_tenant", ginmid.AuthN(h.JWTSecret, h.JWTIssuer, h.JWTAudience), ginmid.Wrap(h.SwitchTenant))
 
 	v1 := r.Group("/v1")
 	v1.POST("/bootstrap", ginmid.RateLimit(rdb, "rl:bootstrap", 10, time.Minute), ginmid.Wrap(h.Bootstrap))
@@ -70,6 +71,7 @@ func main() {
 	v1.POST("/auth/refresh", ginmid.Wrap(h.Refresh))
 	v1.POST("/auth/logout", ginmid.Wrap(h.Logout))
 	v1.POST("/auth/logout_all", ginmid.AuthN(h.JWTSecret, h.JWTIssuer, h.JWTAudience), ginmid.Wrap(h.LogoutAll))
+	v1.POST("/auth/switch_tenant", ginmid.AuthN(h.JWTSecret, h.JWTIssuer, h.JWTAudience), ginmid.Wrap(h.SwitchTenant))
 
 	if err := r.Run(":8080"); err != nil {
 		log.Fatal(err)

--- a/services/auth-api/internal/handler/dto/auth.go
+++ b/services/auth-api/internal/handler/dto/auth.go
@@ -80,3 +80,14 @@ type TenantSummary struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
 }
+
+// Switch tenant
+
+type SwitchTenantRequest struct {
+	TenantID string `json:"tenant_id" binding:"required"`
+}
+
+type SwitchTenantResponse struct {
+	AccessToken string `json:"access_token"`
+	ExpiresIn   int    `json:"expires_in"`
+}

--- a/services/auth-api/internal/handler/switch_tenant_test.go
+++ b/services/auth-api/internal/handler/switch_tenant_test.go
@@ -1,0 +1,126 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	ajwt "anvilkit-auth-template/modules/common-go/pkg/auth/jwt"
+	"anvilkit-auth-template/modules/common-go/pkg/httpx/errcode"
+	"anvilkit-auth-template/modules/common-go/pkg/httpx/ginmid"
+	"anvilkit-auth-template/services/auth-api/internal/testutil"
+)
+
+func TestSwitchTenantSuccessReturnsTokenWithTID(t *testing.T) {
+	db := newTestDB(t)
+	rdb := newTestRedis(t)
+	testutil.TruncateAuthTables(t, db)
+
+	uid := uuid.NewString()
+	tenantID := uuid.NewString()
+	seedAuthUser(t, db, uid, "switch-ok@example.com")
+	_, err := db.Exec(context.Background(), `insert into tenants(id,name,created_at) values($1,$2,now())`, tenantID, "Acme")
+	if err != nil {
+		t.Fatalf("insert tenant: %v", err)
+	}
+	_, err = db.Exec(context.Background(), `insert into tenant_users(tenant_id,user_id,role,created_at) values($1,$2,'member',now())`, tenantID, uid)
+	if err != nil {
+		t.Fatalf("insert tenant_users: %v", err)
+	}
+
+	h := newTestAuthHandler(t, db, rdb)
+	oldToken, err := ajwt.SignAccessToken(h.JWTSecret, h.JWTIssuer, h.JWTAudience, uid, nil, time.Minute)
+	if err != nil {
+		t.Fatalf("sign access token: %v", err)
+	}
+
+	r := newSwitchTenantRouter(h)
+	res := performAuthedJSONRequest(t, r, http.MethodPost, "/v1/auth/switch_tenant", oldToken, map[string]string{"tenant_id": tenantID})
+	if res.Code != http.StatusOK {
+		t.Fatalf("status=%d want=%d body=%s", res.Code, http.StatusOK, res.Body.String())
+	}
+
+	var body struct {
+		Code int `json:"code"`
+		Data struct {
+			AccessToken string `json:"access_token"`
+			ExpiresIn   int    `json:"expires_in"`
+		} `json:"data"`
+	}
+	decodeResponse(t, res, &body)
+	if body.Code != 0 || body.Data.AccessToken == "" {
+		t.Fatalf("unexpected body: %+v", body)
+	}
+	if body.Data.ExpiresIn != 900 {
+		t.Fatalf("expires_in=%d want=900", body.Data.ExpiresIn)
+	}
+
+	claims, err := ajwt.Parse(h.JWTSecret, h.JWTIssuer, h.JWTAudience, body.Data.AccessToken)
+	if err != nil {
+		t.Fatalf("parse switched token: %v", err)
+	}
+	if claims.TID != tenantID {
+		t.Fatalf("claims.tid=%q want=%q", claims.TID, tenantID)
+	}
+}
+
+func TestSwitchTenantForbiddenWhenNotInTenant(t *testing.T) {
+	db := newTestDB(t)
+	rdb := newTestRedis(t)
+	testutil.TruncateAuthTables(t, db)
+
+	uid := uuid.NewString()
+	tenantID := uuid.NewString()
+	seedAuthUser(t, db, uid, "switch-deny@example.com")
+	_, err := db.Exec(context.Background(), `insert into tenants(id,name,created_at) values($1,$2,now())`, tenantID, "NoMembership")
+	if err != nil {
+		t.Fatalf("insert tenant: %v", err)
+	}
+
+	h := newTestAuthHandler(t, db, rdb)
+	token, err := ajwt.SignAccessToken(h.JWTSecret, h.JWTIssuer, h.JWTAudience, uid, nil, time.Minute)
+	if err != nil {
+		t.Fatalf("sign access token: %v", err)
+	}
+
+	r := newSwitchTenantRouter(h)
+	res := performAuthedJSONRequest(t, r, http.MethodPost, "/v1/auth/switch_tenant", token, map[string]string{"tenant_id": tenantID})
+	if res.Code != http.StatusForbidden {
+		t.Fatalf("status=%d want=%d body=%s", res.Code, http.StatusForbidden, res.Body.String())
+	}
+
+	var body struct {
+		Code int `json:"code"`
+		Data struct {
+			Reason string `json:"reason"`
+		} `json:"data"`
+	}
+	decodeResponse(t, res, &body)
+	if body.Code != errcode.Forbidden {
+		t.Fatalf("code=%d want=%d", body.Code, errcode.Forbidden)
+	}
+	if body.Data.Reason != "not_in_tenant" {
+		t.Fatalf("reason=%q want=not_in_tenant", body.Data.Reason)
+	}
+}
+
+func newSwitchTenantRouter(h *Handler) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(ginmid.RequestID(), ginmid.ErrorHandler())
+	r.POST("/v1/auth/switch_tenant", ginmid.AuthN(h.JWTSecret, h.JWTIssuer, h.JWTAudience), ginmid.Wrap(h.SwitchTenant))
+	return r
+}
+
+func seedAuthUser(t *testing.T, db *pgxpool.Pool, uid, email string) {
+	t.Helper()
+	_, err := db.Exec(context.Background(), `insert into users(id,email,status,created_at,updated_at) values($1,$2,1,now(),now())`, uid, email)
+	if err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+}


### PR DESCRIPTION
### Motivation
- Add tenant awareness to access tokens and provide an authenticated endpoint to switch a user's active tenant so downstream services (admin-api etc.) can receive/inspect tid from JWT and logging.

### Description
- Closes #28.
- Key changes: added `SignAccessToken(secret, issuer, audience, uid string, tid *string, ttl time.Duration)` and `tid` claim support in JWT; added `POST /v1/auth/switch_tenant` (also available under `/api/v1/auth/switch_tenant`) that validates membership and returns a new access token containing `tid`; middleware writes `tid` (string) into Gin context as `"tid"` (empty string when absent). Files changed: `modules/common-go/pkg/auth/jwt/jwt.go`, `modules/common-go/pkg/httpx/ginmid/authn.go` (behavior preserved), `services/auth-api/internal/store/store.go`, `services/auth-api/internal/handler/handler.go`, `services/auth-api/internal/handler/dto/auth.go`, `services/auth-api/cmd/auth-api/main.go`, tests, and Postman collection update (`examples/postman/collection.json`).
- Issue #28 Checklist (all completed):
  - [x] 校验用户属于 tenant — implemented `Store.EnsureUserInTenant(ctx, userID, tenantID)` which queries `tenant_users`; failing case returns `403 forbidden` with `reason=not_in_tenant`; verified in `TestSwitchTenantForbiddenWhenNotInTenant` (asserts 403 and reason).
  - [x] 生成包含 tid 的 access token — `SwitchTenant` issues new access token via `SignAccessToken(..., &tenantID, ...)`; verified by parsing returned token in `TestSwitchTenantSuccessReturnsTokenWithTID` and asserting `claims.TID == tenant_id`.
  - [x] middleware 可从 token 解析 tid 写入 context（tid 可为空） — `AuthN` continues to parse claims and calls `c.Set("tid", claims.TID)`; verified by `TestAuthN_SuccessSetsUIDAndTIDInContext` (tid present) and `TestAuthN_SuccessWithoutTIDDoesNotPanic` (tid empty string).
- tid claim design: claim name `tid`, type `string` (UUID string), optional (omitempty in struct); Gin context key `"tid"` with value type `string` (empty when not present).

### Testing
- Unit tests added/updated:
  - `modules/common-go/pkg/httpx/ginmid` tests: `TestAuthN_SuccessSetsUIDAndTIDInContext`, `TestAuthN_SuccessWithoutTIDDoesNotPanic` (both passed).
  - `services/auth-api/internal/handler` tests: `TestSwitchTenantSuccessReturnsTokenWithTID`, `TestSwitchTenantForbiddenWhenNotInTenant` (integration tests using `TEST_DB_DSN` / `TEST_REDIS_ADDR` test helpers passed when run in test environment).
- Commands executed and results:
  - `gofmt -w ...` applied to modified files — OK.
  - `go test ./services/auth-api/... -count=1` — OK.
  - `go test ./modules/common-go/... -count=1` — OK.
  - `go test ./... -count=1` — OK.
  - `golangci-lint run` — skipped/failed due to local config/tool version mismatch (`unsupported version of the configuration`).
- Acceptance verification summary:
  - Switching to a tenant returns `200` with `{access_token, expires_in}` and parsed token contains `tid == tenant_id` (asserted in `TestSwitchTenantSuccessReturnsTokenWithTID`).
  - Attempting to switch to a tenant the user is not a member of returns `403 forbidden` with response data `reason = "not_in_tenant"` (asserted in `TestSwitchTenantForbiddenWhenNotInTenant`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bd3367bf4833381a18e3d69e75a48)