### PR TITLE
fix(admin-api): remove duplicate enforce declaration in handler.go

### DIFF
--- a/services/admin-api/internal/handler/handler.go
+++ b/services/admin-api/internal/handler/handler.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/casbin/casbin/v2"
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgconn"
 
 	"anvilkit-auth-template/modules/common-go/pkg/httpx/apperr"
@@ -214,9 +213,6 @@ func validateUserID(id string) error {
 	}
 	return nil
 }
-
-func (h *Handler) enforce(c *gin.Context, roles []string, tid string) error {
-	dom := fmt.Sprintf("tenant:%s", tid)
 
 func (h *Handler) enforce(c *gin.Context, roles []string, tid string) error {
 	dom := fmt.Sprintf("tenant:%s", tid)


### PR DESCRIPTION
### Motivation
- A duplicate `enforce` function declaration in `services/admin-api/internal/handler/handler.go` broke Go parsing and caused compilation failures for `admin-api` and CI builds.
- The duplicate also caused an unused import (`github.com/google/uuid`) to remain after fixing, which would make the file fail to compile.

### Description
- Removed the accidental duplicate `func (h *Handler) enforce(c *gin.Context, roles []string, tid string) error` declaration and kept a single complete implementation in `services/admin-api/internal/handler/handler.go`.
- Removed the now-unused import `github.com/google/uuid` from the file.
- Ran `gofmt` on the modified file to ensure formatting is consistent.

### Testing
- Ran `(cd services/admin-api && go test ./... -count=1)` and it passed for the module (`ok    anvilkit-auth-template/services/admin-api/internal/handler`).
- Ran `go test ./... -count=1` at repository root and it completed successfully (no test files in some packages reported as `?`).
- Verified build with `(cd services/admin-api && go build ./cmd/admin-api)` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dfcf1adf88333a59e9f891ecccede)