### PR TITLE
Make deploy migrations upload idempotent and improve diagnostics

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -360,7 +360,12 @@ jobs:
           set -euo pipefail
           port="${DEPLOY_PORT:-22}"
           ssh -p "$port" -o StrictHostKeyChecking=accept-new "$DEPLOY_USER@$DEPLOY_HOST" \
-            "mkdir -p '$DEPLOY_PATH/deploy' '$DEPLOY_PATH/scripts' '$DEPLOY_PATH/migrations/auth-api' '$DEPLOY_PATH/migrations/admin-api'"
+            "mkdir -p '$DEPLOY_PATH/deploy' '$DEPLOY_PATH/scripts'"
+
+          # Reset migrations directory to keep deploy idempotent and avoid stale/legacy files
+          # from previous releases causing count mismatches.
+          ssh -p "$port" -o StrictHostKeyChecking=accept-new "$DEPLOY_USER@$DEPLOY_HOST" \
+            "rm -rf '$DEPLOY_PATH/migrations' && mkdir -p '$DEPLOY_PATH/migrations/auth-api' '$DEPLOY_PATH/migrations/admin-api'"
 
           scp -P "$port" -o StrictHostKeyChecking=accept-new deploy/docker-compose.prod.yml \
             "$DEPLOY_USER@$DEPLOY_HOST:$DEPLOY_PATH/deploy/docker-compose.prod.yml"
@@ -384,12 +389,12 @@ jobs:
           if [[ "$remote_count" -ne "$local_count" ]]; then
             echo "::error::Migration file count mismatch: local=$local_count remote=$remote_count" >&2
             ssh -p "$port" -o StrictHostKeyChecking=accept-new "$DEPLOY_USER@$DEPLOY_HOST" \
-              "ls -la '$DEPLOY_PATH/migrations'" >&2
+              "ls -la '$DEPLOY_PATH/migrations'; ls -la '$DEPLOY_PATH/migrations/auth-api'; ls -la '$DEPLOY_PATH/migrations/admin-api'" >&2
             exit 1
           fi
           echo "Migrations uploaded: $remote_count file(s)"
           ssh -p "$port" -o StrictHostKeyChecking=accept-new "$DEPLOY_USER@$DEPLOY_HOST" \
-            "ls -la '$DEPLOY_PATH/migrations'"
+            "ls -la '$DEPLOY_PATH/migrations'; ls -la '$DEPLOY_PATH/migrations/auth-api'; ls -la '$DEPLOY_PATH/migrations/admin-api'"
 
       - name: Run remote deployment
         env:


### PR DESCRIPTION
### Motivation
- The remote migration-count check failed when old/legacy SQL files lived at `$DEPLOY_PATH/migrations` root (or otherwise duplicated), causing `remote_count` to exceed `local_count` and making the check non‑idempotent for repeated/upgrade deploys.

### Description
- Reset the remote migrations area before uploading by running `rm -rf "$DEPLOY_PATH/migrations" && mkdir -p "$DEPLOY_PATH/migrations/auth-api" "$DEPLOY_PATH/migrations/admin-api"` so uploads do not accumulate stale files; this change is applied in `.github/workflows/deploy.yml`.
- Preserve the strict `remote_count == local_count` validation after the reset and improve diagnostics by printing `ls -la` for the migrations root and both `auth-api`/`admin-api` subdirectories on success and on mismatch.
- Only `.github/workflows/deploy.yml` was modified and `remote_deploy.sh` does not require changes.

### Testing
- Ran automated repository checks including `git diff --check` and reviewed the diff for `.github/workflows/deploy.yml` to validate the change; both checks passed. }

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699eddefb3348333b79da6164b91d028)