### PR TITLE
feat(auth-api): resend verification email with rate limiting

### DIFF
--- a/examples/postman/collection.json
+++ b/examples/postman/collection.json
@@ -108,6 +108,37 @@
       ]
     },
     {
+      "name": "resend-verification",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "url": "{{base_url_auth}}/api/v1/auth/resend-verification",
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"email\": \"{{register_email}}\"\n}"
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "const b = pm.response.json();",
+              "pm.test('status accepted', ()=> pm.expect(pm.response.code).to.eql(202));",
+              "pm.test('envelope code=0', ()=> pm.expect(b.code).to.eql(0));",
+              "pm.test('resend message', ()=> pm.expect(b.data.message).to.eql('Verification email sent'));",
+              "pm.test('retry_after 90', ()=> pm.expect(b.data.retry_after).to.eql(90));"
+            ]
+          }
+        }
+      ]
+    },
+    {
       "name": "verify-email (otp)",
       "request": {
         "method": "POST",

--- a/services/auth-api/cmd/auth-api/main.go
+++ b/services/auth-api/cmd/auth-api/main.go
@@ -59,6 +59,7 @@ func main() {
 	v1 := r.Group("/api/v1")
 	v1.POST("/bootstrap", ginmid.RateLimit(rdb, "rl:bootstrap", 10, time.Minute), ginmid.Wrap(h.Bootstrap))
 	v1.POST("/auth/register", ginmid.RateLimit(rdb, "rl:register", 20, time.Minute), ginmid.Wrap(h.Register))
+	v1.POST("/auth/resend-verification", ginmid.Wrap(h.ResendVerification))
 	v1.POST("/auth/verify-email", ginmid.RateLimit(rdb, "rl:verify-email", 60, time.Minute), ginmid.Wrap(h.VerifyEmail))
 	v1.GET("/auth/verify-magic-link", ginmid.RateLimit(rdb, "rl:verify-magic-link", 60, time.Minute), ginmid.Wrap(h.VerifyMagicLink))
 	v1.POST("/auth/login", ginmid.RateLimit(rdb, "rl:login", 30, time.Minute), ginmid.Wrap(h.Login))

--- a/services/auth-api/cmd/auth-api/main.go
+++ b/services/auth-api/cmd/auth-api/main.go
@@ -59,7 +59,7 @@ func main() {
 	v1 := r.Group("/api/v1")
 	v1.POST("/bootstrap", ginmid.RateLimit(rdb, "rl:bootstrap", 10, time.Minute), ginmid.Wrap(h.Bootstrap))
 	v1.POST("/auth/register", ginmid.RateLimit(rdb, "rl:register", 20, time.Minute), ginmid.Wrap(h.Register))
-	v1.POST("/auth/resend-verification", ginmid.Wrap(h.ResendVerification))
+	v1.POST("/auth/resend-verification", ginmid.RateLimit(rdb, "rl:resend-verification", 15, time.Minute), ginmid.Wrap(h.ResendVerification))
 	v1.POST("/auth/verify-email", ginmid.RateLimit(rdb, "rl:verify-email", 60, time.Minute), ginmid.Wrap(h.VerifyEmail))
 	v1.GET("/auth/verify-magic-link", ginmid.RateLimit(rdb, "rl:verify-magic-link", 60, time.Minute), ginmid.Wrap(h.VerifyMagicLink))
 	v1.POST("/auth/login", ginmid.RateLimit(rdb, "rl:login", 30, time.Minute), ginmid.Wrap(h.Login))

--- a/services/auth-api/internal/handler/dto/auth.go
+++ b/services/auth-api/internal/handler/dto/auth.go
@@ -24,6 +24,17 @@ type RegisterResponse struct {
 	User UserSummary `json:"user"`
 }
 
+// Resend verification
+
+type ResendVerificationRequest struct {
+	Email string `json:"email" binding:"required"`
+}
+
+type ResendVerificationResponse struct {
+	Message    string `json:"message"`
+	RetryAfter int    `json:"retry_after"`
+}
+
 // Verify email
 
 type VerifyEmailRequest struct {

--- a/services/auth-api/internal/handler/handler.go
+++ b/services/auth-api/internal/handler/handler.go
@@ -250,20 +250,27 @@ func (h *Handler) ResendVerification(c *gin.Context) error {
 		}
 		return err
 	}
+	rollbackResend := func(cause error) error {
+		rollbackErr := h.Store.RollbackResendVerification(c, resend)
+		if rollbackErr == nil {
+			return cause
+		}
+		return fmt.Errorf("%w; rollback resend verification: %v", cause, rollbackErr)
+	}
 
 	magicLinkState, err := getOrCreateMagicLinkState(c)
 	if err != nil {
-		return err
+		return rollbackResend(err)
 	}
 	magicLink := buildMagicLink(h.PublicBaseURL, magicToken, magicLinkState)
 	htmlBody, textBody := buildVerificationEmailBody(otp, magicLink)
 
 	if h.Redis == nil {
-		return errors.New("redis_unavailable")
+		return rollbackResend(errors.New("redis_unavailable"))
 	}
 	q, err := queue.New(h.Redis)
 	if err != nil {
-		return err
+		return rollbackResend(err)
 	}
 	if err := q.EnqueueContext(c, emailQueueName, emailSendJob{
 		RecordID:  resend.EmailRecordID,
@@ -274,7 +281,7 @@ func (h *Handler) ResendVerification(c *gin.Context) error {
 		OTP:       otp,
 		MagicLink: magicLink,
 	}); err != nil {
-		return err
+		return rollbackResend(err)
 	}
 
 	setMagicLinkStateCookie(c, magicLinkState, expiresAt)

--- a/services/auth-api/internal/handler/handler.go
+++ b/services/auth-api/internal/handler/handler.go
@@ -9,6 +9,7 @@ import (
 	"net/mail"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -45,6 +46,18 @@ const (
 
 var otpCodePattern = regexp.MustCompile(`^\d{6}$`)
 var magicLinkStatePattern = regexp.MustCompile(`^[A-Za-z0-9_-]{32}$`)
+var resendRateLimitScript = goredis.NewScript(`
+local current = redis.call('INCR', KEYS[1])
+if current == 1 then
+  redis.call('EXPIRE', KEYS[1], ARGV[1])
+end
+local ttl = redis.call('TTL', KEYS[1])
+if ttl <= 0 then
+  redis.call('EXPIRE', KEYS[1], ARGV[1])
+  ttl = redis.call('TTL', KEYS[1])
+end
+return {current, ttl}
+`)
 
 type emailSendJob struct {
 	RecordID  string `json:"record_id"`
@@ -670,23 +683,31 @@ func (h *Handler) checkResendRateLimit(ctx context.Context, emailAddr string) (i
 	if h.Redis == nil {
 		return 0, 0, errors.New("redis_unavailable")
 	}
+	windowSeconds := int64(resendVerificationWindow / time.Second)
+	if windowSeconds <= 0 {
+		windowSeconds = 90
+	}
 	key := fmt.Sprintf("resend:%s", emailAddr)
-	count, err := h.Redis.Incr(ctx, key).Result()
+	raw, err := resendRateLimitScript.Run(ctx, h.Redis, []string{key}, windowSeconds).Result()
 	if err != nil {
 		return 0, 0, err
 	}
-	if count == 1 {
-		if err := h.Redis.Expire(ctx, key, resendVerificationWindow).Err(); err != nil {
-			return 0, 0, err
-		}
+
+	values, ok := raw.([]interface{})
+	if !ok || len(values) != 2 {
+		return 0, 0, errors.New("invalid_resend_rate_limit_result")
 	}
-	retryAfter, err := h.Redis.TTL(ctx, key).Result()
+	count, err := parseRedisInteger(values[0])
 	if err != nil {
 		return 0, 0, err
 	}
-	retryAfterSeconds := int(retryAfter / time.Second)
+	retryAfter, err := parseRedisInteger(values[1])
+	if err != nil {
+		return 0, 0, err
+	}
+	retryAfterSeconds := int(retryAfter)
 	if retryAfterSeconds <= 0 {
-		retryAfterSeconds = int(resendVerificationWindow / time.Second)
+		retryAfterSeconds = int(windowSeconds)
 	}
 	return count, retryAfterSeconds, nil
 }
@@ -727,4 +748,19 @@ func getOrCreateMagicLinkState(c *gin.Context) (string, error) {
 		}
 	}
 	return util.RandomToken(magicLinkStateByteLen)
+}
+
+func parseRedisInteger(v any) (int64, error) {
+	switch n := v.(type) {
+	case int64:
+		return n, nil
+	case int:
+		return int64(n), nil
+	case string:
+		return strconv.ParseInt(n, 10, 64)
+	case []byte:
+		return strconv.ParseInt(string(n), 10, 64)
+	default:
+		return 0, fmt.Errorf("unexpected redis integer type: %T", v)
+	}
 }

--- a/services/auth-api/internal/handler/handler.go
+++ b/services/auth-api/internal/handler/handler.go
@@ -245,11 +245,8 @@ func (h *Handler) ResendVerification(c *gin.Context) error {
 
 	resend, err := h.Store.ResendVerification(c, emailAddr, otp, magicToken, expiresAt, now)
 	if err != nil {
-		if errors.Is(err, store.ErrResendUserNotFound) {
-			return apperr.BadRequest(err).WithData(map[string]any{"reason": "user_not_found"})
-		}
-		if errors.Is(err, store.ErrResendAlreadyVerified) {
-			return apperr.BadRequest(err).WithData(map[string]any{"reason": "already_verified"})
+		if errors.Is(err, store.ErrResendUserNotFound) || errors.Is(err, store.ErrResendAlreadyVerified) {
+			return apperr.BadRequest(errors.New("resend_not_allowed")).WithData(map[string]any{"reason": "resend_not_allowed"})
 		}
 		return err
 	}

--- a/services/auth-api/internal/handler/handler.go
+++ b/services/auth-api/internal/handler/handler.go
@@ -34,6 +34,9 @@ const (
 	verificationTTL                   = 15 * time.Minute
 	verificationEmailSubject          = "Verify your email"
 	verificationAcceptedMessage       = "registration accepted, please check your email for verification"
+	resendVerificationWindow          = 90 * time.Second
+	resendVerificationLimit           = 6
+	resendVerificationMessage         = "Verification email sent"
 	magicLinkStateCookieName          = "ak_magic_link_state"
 	magicLinkSuccessPath              = "/verify-email/success"
 	magicLinkStateByteLen             = 24
@@ -183,6 +186,95 @@ func (h *Handler) Register(c *gin.Context) error {
 		Message:   verificationAcceptedMessage,
 		Data: dto.RegisterResponse{
 			User: dto.UserSummary{ID: registered.User.ID, Email: registered.User.Email},
+		},
+	})
+	return nil
+}
+
+func (h *Handler) ResendVerification(c *gin.Context) error {
+	var req dto.ResendVerificationRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		return apperr.BadRequest(err)
+	}
+
+	emailAddr := strings.TrimSpace(strings.ToLower(req.Email))
+	if _, err := mail.ParseAddress(emailAddr); err != nil {
+		return apperr.BadRequest(fmt.Errorf("invalid_email"))
+	}
+
+	count, retryAfter, err := h.checkResendRateLimit(c, emailAddr)
+	if err != nil {
+		return err
+	}
+	if count > resendVerificationLimit {
+		return apperr.RateLimited(errors.New("resend_rate_limited")).WithData(map[string]any{
+			"reason":      "too_many_requests",
+			"retry_after": retryAfter,
+		})
+	}
+	if count > 1 {
+		return apperr.RateLimited(errors.New("resend_cooldown_active")).WithData(map[string]any{
+			"reason":      "cooldown_active",
+			"retry_after": retryAfter,
+		})
+	}
+
+	otp, err := commonemail.GenerateOTP()
+	if err != nil {
+		return err
+	}
+	magicToken, err := commonemail.GenerateMagicToken()
+	if err != nil {
+		return err
+	}
+	now := time.Now()
+	expiresAt := now.Add(verificationTTL)
+
+	resend, err := h.Store.ResendVerification(c, emailAddr, otp, magicToken, expiresAt, now)
+	if err != nil {
+		if errors.Is(err, store.ErrResendUserNotFound) {
+			return apperr.BadRequest(err).WithData(map[string]any{"reason": "user_not_found"})
+		}
+		if errors.Is(err, store.ErrResendAlreadyVerified) {
+			return apperr.BadRequest(err).WithData(map[string]any{"reason": "already_verified"})
+		}
+		return err
+	}
+
+	magicLinkState, err := getOrCreateMagicLinkState(c)
+	if err != nil {
+		return err
+	}
+	magicLink := buildMagicLink(h.PublicBaseURL, magicToken, magicLinkState)
+	htmlBody, textBody := buildVerificationEmailBody(otp, magicLink)
+
+	if h.Redis == nil {
+		return errors.New("redis_unavailable")
+	}
+	q, err := queue.New(h.Redis)
+	if err != nil {
+		return err
+	}
+	if err := q.EnqueueContext(c, emailQueueName, emailSendJob{
+		RecordID:  resend.EmailRecordID,
+		To:        resend.UserEmail,
+		Subject:   verificationEmailSubject,
+		HTMLBody:  htmlBody,
+		TextBody:  textBody,
+		OTP:       otp,
+		MagicLink: magicLink,
+	}); err != nil {
+		return err
+	}
+
+	setMagicLinkStateCookie(c, magicLinkState, expiresAt)
+	c.JSON(http.StatusAccepted, resp.Envelope{
+		RequestID: c.GetString("request_id"),
+		Code:      0,
+		Message:   "ok",
+		Data: dto.ResendVerificationResponse{
+			Message:    resendVerificationMessage,
+			RetryAfter: int(resendVerificationWindow / time.Second),
 		},
 	})
 	return nil
@@ -574,6 +666,31 @@ func (h *Handler) issueTokens(ctx context.Context, uid, tid, userAgent, ip strin
 	return at, rt, nil
 }
 
+func (h *Handler) checkResendRateLimit(ctx context.Context, emailAddr string) (int64, int, error) {
+	if h.Redis == nil {
+		return 0, 0, errors.New("redis_unavailable")
+	}
+	key := fmt.Sprintf("resend:%s", emailAddr)
+	count, err := h.Redis.Incr(ctx, key).Result()
+	if err != nil {
+		return 0, 0, err
+	}
+	if count == 1 {
+		if err := h.Redis.Expire(ctx, key, resendVerificationWindow).Err(); err != nil {
+			return 0, 0, err
+		}
+	}
+	retryAfter, err := h.Redis.TTL(ctx, key).Result()
+	if err != nil {
+		return 0, 0, err
+	}
+	retryAfterSeconds := int(retryAfter / time.Second)
+	if retryAfterSeconds <= 0 {
+		retryAfterSeconds = int(resendVerificationWindow / time.Second)
+	}
+	return count, retryAfterSeconds, nil
+}
+
 func (h *Handler) isLoginRateLimited(ctx context.Context, key string) (bool, error) {
 	if h.Redis == nil {
 		return false, nil
@@ -600,4 +717,14 @@ func (h *Handler) increaseLoginFailCount(ctx context.Context, key string) {
 
 func NotFound(c *gin.Context) {
 	resp.Fail(c, http.StatusNotFound, 1004, "not_found", map[string]any{"reason": "route_not_found"})
+}
+
+func getOrCreateMagicLinkState(c *gin.Context) (string, error) {
+	if cookieState, err := c.Cookie(magicLinkStateCookieName); err == nil {
+		cookieState = strings.TrimSpace(cookieState)
+		if isValidMagicLinkState(cookieState) {
+			return cookieState, nil
+		}
+	}
+	return util.RandomToken(magicLinkStateByteLen)
 }

--- a/services/auth-api/internal/handler/resend_verification_test.go
+++ b/services/auth-api/internal/handler/resend_verification_test.go
@@ -306,8 +306,8 @@ values($1,$2,1,now(),now(),now())`,
 	if body.Code != errcode.BadRequest {
 		t.Fatalf("code=%d want=%d", body.Code, errcode.BadRequest)
 	}
-	if body.Data.Reason != "already_verified" {
-		t.Fatalf("reason=%q want=%q", body.Data.Reason, "already_verified")
+	if body.Data.Reason != "resend_not_allowed" {
+		t.Fatalf("reason=%q want=%q", body.Data.Reason, "resend_not_allowed")
 	}
 
 	q, err := queue.New(rdb)
@@ -320,6 +320,36 @@ values($1,$2,1,now(),now(),now())`,
 	}
 	if n != 0 {
 		t.Fatalf("queue length=%d want=0", n)
+	}
+}
+
+func TestResendVerificationUserNotFoundReturnsGenericBadRequest(t *testing.T) {
+	db := newTestDB(t)
+	rdb := newTestRedis(t)
+	testutil.TruncateAuthTables(t, db)
+	testutil.FlushRedisKeys(t, rdb, emailQueueName)
+	testutil.FlushRedisKeys(t, rdb, "resend:*")
+
+	r := newResendVerificationRouter(t, db, rdb)
+	res := performJSONRequest(t, r, http.MethodPost, "/v1/auth/resend-verification", map[string]string{
+		"email": "missing-resend-user@example.com",
+	})
+	if res.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d want=%d body=%s", res.Code, http.StatusBadRequest, res.Body.String())
+	}
+
+	var body struct {
+		Code int `json:"code"`
+		Data struct {
+			Reason string `json:"reason"`
+		} `json:"data"`
+	}
+	decodeResponse(t, res, &body)
+	if body.Code != errcode.BadRequest {
+		t.Fatalf("code=%d want=%d", body.Code, errcode.BadRequest)
+	}
+	if body.Data.Reason != "resend_not_allowed" {
+		t.Fatalf("reason=%q want=%q", body.Data.Reason, "resend_not_allowed")
 	}
 }
 

--- a/services/auth-api/internal/handler/resend_verification_test.go
+++ b/services/auth-api/internal/handler/resend_verification_test.go
@@ -1,0 +1,335 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5/pgxpool"
+	goredis "github.com/redis/go-redis/v9"
+
+	"anvilkit-auth-template/modules/common-go/pkg/httpx/errcode"
+	"anvilkit-auth-template/modules/common-go/pkg/httpx/ginmid"
+	"anvilkit-auth-template/modules/common-go/pkg/queue"
+	"anvilkit-auth-template/services/auth-api/internal/testutil"
+)
+
+func TestResendVerificationSuccess(t *testing.T) {
+	db := newTestDB(t)
+	rdb := newTestRedis(t)
+	testutil.TruncateAuthTables(t, db)
+	testutil.FlushRedisKeys(t, rdb, emailQueueName)
+	testutil.FlushRedisKeys(t, rdb, "resend:*")
+
+	r := newResendVerificationRouter(t, db, rdb)
+	registerRes := performJSONRequest(t, r, http.MethodPost, "/v1/auth/register", map[string]string{
+		"email":    "resend-ok@example.com",
+		"password": "Passw0rd!",
+	})
+	if registerRes.Code != http.StatusAccepted {
+		t.Fatalf("register status=%d want=%d body=%s", registerRes.Code, http.StatusAccepted, registerRes.Body.String())
+	}
+	if _, err := popQueuedJob(t, rdb); err != nil {
+		t.Fatalf("pop register queued job: %v", err)
+	}
+
+	oldExpiresByID := map[string]time.Time{}
+	rows, err := db.Query(context.Background(), `
+select ev.id, ev.expires_at
+from email_verifications ev
+join users u on u.id = ev.user_id
+where u.email = $1
+  and ev.verified_at is null
+  and ev.expires_at > now()`,
+		"resend-ok@example.com",
+	)
+	if err != nil {
+		t.Fatalf("query old verification rows: %v", err)
+	}
+	for rows.Next() {
+		var id string
+		var expiresAt time.Time
+		if err := rows.Scan(&id, &expiresAt); err != nil {
+			t.Fatalf("scan old verification row: %v", err)
+		}
+		oldExpiresByID[id] = expiresAt
+	}
+	rows.Close()
+	if rows.Err() != nil {
+		t.Fatalf("iterate old verification rows: %v", rows.Err())
+	}
+	if len(oldExpiresByID) != 2 {
+		t.Fatalf("old active verification row count=%d want=2", len(oldExpiresByID))
+	}
+
+	res := performJSONRequest(t, r, http.MethodPost, "/v1/auth/resend-verification", map[string]string{
+		"email": "resend-ok@example.com",
+	})
+	if res.Code != http.StatusAccepted {
+		t.Fatalf("status=%d want=%d body=%s", res.Code, http.StatusAccepted, res.Body.String())
+	}
+	var body struct {
+		Code int `json:"code"`
+		Data struct {
+			Message    string `json:"message"`
+			RetryAfter int    `json:"retry_after"`
+		} `json:"data"`
+	}
+	decodeResponse(t, res, &body)
+	if body.Code != 0 {
+		t.Fatalf("code=%d want=0 body=%s", body.Code, res.Body.String())
+	}
+	if body.Data.Message != resendVerificationMessage || body.Data.RetryAfter != 90 {
+		t.Fatalf("unexpected response data: %+v", body.Data)
+	}
+
+	job, err := popQueuedJob(t, rdb)
+	if err != nil {
+		t.Fatalf("pop resend queued job: %v", err)
+	}
+	if job.To != "resend-ok@example.com" {
+		t.Fatalf("job to=%q want=%q", job.To, "resend-ok@example.com")
+	}
+	if !otpPattern.MatchString(job.OTP) {
+		t.Fatalf("job otp=%q should be a 6-digit numeric code", job.OTP)
+	}
+	parsedMagicLink, err := url.Parse(job.MagicLink)
+	if err != nil {
+		t.Fatalf("parse magic link: %v", err)
+	}
+	token := parsedMagicLink.Query().Get("token")
+	state := parsedMagicLink.Query().Get("state")
+	if token == "" || state == "" {
+		t.Fatalf("job magic_link=%q missing token/state", job.MagicLink)
+	}
+
+	stateCookie := findCookieByName(res, magicLinkStateCookieName)
+	if stateCookie == nil {
+		t.Fatalf("expected %s cookie to be set", magicLinkStateCookieName)
+	}
+	if stateCookie.Value != state {
+		t.Fatalf("cookie state=%q want=%q", stateCookie.Value, state)
+	}
+
+	for id, oldExpiresAt := range oldExpiresByID {
+		var newExpiresAt time.Time
+		if err := db.QueryRow(context.Background(), `select expires_at from email_verifications where id=$1`, id).Scan(&newExpiresAt); err != nil {
+			t.Fatalf("query updated expires_at by id: %v", err)
+		}
+		if !newExpiresAt.Before(oldExpiresAt) {
+			t.Fatalf("verification row %s expires_at=%s should be earlier than old value=%s", id, newExpiresAt, oldExpiresAt)
+		}
+	}
+
+	var activeCount int
+	if err := db.QueryRow(context.Background(), `
+select count(1)
+from email_verifications ev
+join users u on u.id = ev.user_id
+where u.email = $1
+  and ev.verified_at is null
+  and ev.expires_at > now()`,
+		"resend-ok@example.com",
+	).Scan(&activeCount); err != nil {
+		t.Fatalf("count active verification rows: %v", err)
+	}
+	if activeCount != 2 {
+		t.Fatalf("active verification row count=%d want=2", activeCount)
+	}
+
+	var emailRecordCount int
+	if err := db.QueryRow(context.Background(), `
+select count(1)
+from email_records er
+join users u on u.id = er.user_id
+where u.email = $1`,
+		"resend-ok@example.com",
+	).Scan(&emailRecordCount); err != nil {
+		t.Fatalf("count email records: %v", err)
+	}
+	if emailRecordCount != 2 {
+		t.Fatalf("email record count=%d want=2", emailRecordCount)
+	}
+}
+
+func TestResendVerificationRateLimit(t *testing.T) {
+	t.Run("cooldown blocks immediate resend", func(t *testing.T) {
+		db := newTestDB(t)
+		rdb := newTestRedis(t)
+		testutil.TruncateAuthTables(t, db)
+		testutil.FlushRedisKeys(t, rdb, emailQueueName)
+		testutil.FlushRedisKeys(t, rdb, "resend:*")
+
+		r := newResendVerificationRouter(t, db, rdb)
+		registerRes := performJSONRequest(t, r, http.MethodPost, "/v1/auth/register", map[string]string{
+			"email":    "resend-cooldown@example.com",
+			"password": "Passw0rd!",
+		})
+		if registerRes.Code != http.StatusAccepted {
+			t.Fatalf("register status=%d want=%d body=%s", registerRes.Code, http.StatusAccepted, registerRes.Body.String())
+		}
+		if _, err := popQueuedJob(t, rdb); err != nil {
+			t.Fatalf("pop register queued job: %v", err)
+		}
+
+		first := performJSONRequest(t, r, http.MethodPost, "/v1/auth/resend-verification", map[string]string{
+			"email": "resend-cooldown@example.com",
+		})
+		if first.Code != http.StatusAccepted {
+			t.Fatalf("first resend status=%d want=%d body=%s", first.Code, http.StatusAccepted, first.Body.String())
+		}
+		if _, err := popQueuedJob(t, rdb); err != nil {
+			t.Fatalf("pop first resend queued job: %v", err)
+		}
+
+		second := performJSONRequest(t, r, http.MethodPost, "/v1/auth/resend-verification", map[string]string{
+			"email": "resend-cooldown@example.com",
+		})
+		if second.Code != http.StatusTooManyRequests {
+			t.Fatalf("second resend status=%d want=%d body=%s", second.Code, http.StatusTooManyRequests, second.Body.String())
+		}
+		var body struct {
+			Code int `json:"code"`
+			Data struct {
+				Reason     string `json:"reason"`
+				RetryAfter int    `json:"retry_after"`
+			} `json:"data"`
+		}
+		decodeResponse(t, second, &body)
+		if body.Code != errcode.RateLimited {
+			t.Fatalf("code=%d want=%d", body.Code, errcode.RateLimited)
+		}
+		if body.Data.Reason != "cooldown_active" {
+			t.Fatalf("reason=%q want=%q", body.Data.Reason, "cooldown_active")
+		}
+		if body.Data.RetryAfter <= 0 || body.Data.RetryAfter > int(resendVerificationWindow/time.Second) {
+			t.Fatalf("retry_after=%d should be within (0,%d]", body.Data.RetryAfter, int(resendVerificationWindow/time.Second))
+		}
+	})
+
+	t.Run("over limit returns too_many_requests", func(t *testing.T) {
+		db := newTestDB(t)
+		rdb := newTestRedis(t)
+		testutil.TruncateAuthTables(t, db)
+		testutil.FlushRedisKeys(t, rdb, emailQueueName)
+		testutil.FlushRedisKeys(t, rdb, "resend:*")
+
+		r := newResendVerificationRouter(t, db, rdb)
+		registerRes := performJSONRequest(t, r, http.MethodPost, "/v1/auth/register", map[string]string{
+			"email":    "resend-over-limit@example.com",
+			"password": "Passw0rd!",
+		})
+		if registerRes.Code != http.StatusAccepted {
+			t.Fatalf("register status=%d want=%d body=%s", registerRes.Code, http.StatusAccepted, registerRes.Body.String())
+		}
+		if _, err := popQueuedJob(t, rdb); err != nil {
+			t.Fatalf("pop register queued job: %v", err)
+		}
+
+		key := "resend:resend-over-limit@example.com"
+		if err := rdb.Set(context.Background(), key, resendVerificationLimit, resendVerificationWindow).Err(); err != nil {
+			t.Fatalf("preset resend key: %v", err)
+		}
+
+		res := performJSONRequest(t, r, http.MethodPost, "/v1/auth/resend-verification", map[string]string{
+			"email": "resend-over-limit@example.com",
+		})
+		if res.Code != http.StatusTooManyRequests {
+			t.Fatalf("status=%d want=%d body=%s", res.Code, http.StatusTooManyRequests, res.Body.String())
+		}
+		var body struct {
+			Code int `json:"code"`
+			Data struct {
+				Reason     string `json:"reason"`
+				RetryAfter int    `json:"retry_after"`
+			} `json:"data"`
+		}
+		decodeResponse(t, res, &body)
+		if body.Code != errcode.RateLimited {
+			t.Fatalf("code=%d want=%d", body.Code, errcode.RateLimited)
+		}
+		if body.Data.Reason != "too_many_requests" {
+			t.Fatalf("reason=%q want=%q", body.Data.Reason, "too_many_requests")
+		}
+		if body.Data.RetryAfter <= 0 || body.Data.RetryAfter > int(resendVerificationWindow/time.Second) {
+			t.Fatalf("retry_after=%d should be within (0,%d]", body.Data.RetryAfter, int(resendVerificationWindow/time.Second))
+		}
+
+		q, err := queue.New(rdb)
+		if err != nil {
+			t.Fatalf("new queue: %v", err)
+		}
+		n, err := q.QueueLength(emailQueueName)
+		if err != nil {
+			t.Fatalf("queue length: %v", err)
+		}
+		if n != 0 {
+			t.Fatalf("queue length=%d want=0", n)
+		}
+	})
+}
+
+func TestResendVerificationVerifiedUserReturnsBadRequest(t *testing.T) {
+	db := newTestDB(t)
+	rdb := newTestRedis(t)
+	testutil.TruncateAuthTables(t, db)
+	testutil.FlushRedisKeys(t, rdb, emailQueueName)
+	testutil.FlushRedisKeys(t, rdb, "resend:*")
+
+	if _, err := db.Exec(context.Background(), `
+insert into users(id,email,status,email_verified_at,created_at,updated_at)
+values($1,$2,1,now(),now(),now())`,
+		"verified-resend-user",
+		"verified-resend@example.com",
+	); err != nil {
+		t.Fatalf("seed verified user: %v", err)
+	}
+
+	r := newResendVerificationRouter(t, db, rdb)
+	res := performJSONRequest(t, r, http.MethodPost, "/v1/auth/resend-verification", map[string]string{
+		"email": "verified-resend@example.com",
+	})
+	if res.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d want=%d body=%s", res.Code, http.StatusBadRequest, res.Body.String())
+	}
+
+	var body struct {
+		Code int `json:"code"`
+		Data struct {
+			Reason string `json:"reason"`
+		} `json:"data"`
+	}
+	decodeResponse(t, res, &body)
+	if body.Code != errcode.BadRequest {
+		t.Fatalf("code=%d want=%d", body.Code, errcode.BadRequest)
+	}
+	if body.Data.Reason != "already_verified" {
+		t.Fatalf("reason=%q want=%q", body.Data.Reason, "already_verified")
+	}
+
+	q, err := queue.New(rdb)
+	if err != nil {
+		t.Fatalf("new queue: %v", err)
+	}
+	n, err := q.QueueLength(emailQueueName)
+	if err != nil {
+		t.Fatalf("queue length: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("queue length=%d want=0", n)
+	}
+}
+
+func newResendVerificationRouter(t *testing.T, db *pgxpool.Pool, rdb *goredis.Client) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(ginmid.RequestID(), ginmid.ErrorHandler())
+	h := newTestAuthHandler(t, db, rdb)
+	r.POST("/v1/auth/register", ginmid.Wrap(h.Register))
+	r.POST("/v1/auth/resend-verification", ginmid.Wrap(h.ResendVerification))
+	return r
+}

--- a/services/auth-api/internal/store/store.go
+++ b/services/auth-api/internal/store/store.go
@@ -63,10 +63,18 @@ type RegisterWithVerificationResult struct {
 	EmailRecordID string
 }
 
+type RevokedVerificationSnapshot struct {
+	ID        string
+	ExpiresAt time.Time
+}
+
 type ResendVerificationResult struct {
-	UserID        string
-	UserEmail     string
-	EmailRecordID string
+	UserID               string
+	UserEmail            string
+	EmailRecordID        string
+	OTPVerificationID    string
+	MagicVerificationID  string
+	RevokedVerifications []RevokedVerificationSnapshot
 }
 
 type LoginUser struct {
@@ -196,6 +204,33 @@ for update`,
 		return nil, ErrResendAlreadyVerified
 	}
 
+	rows, err := tx.Query(ctx, `
+select id, expires_at
+from email_verifications
+where user_id = $1
+  and verified_at is null
+  and expires_at > $2
+for update`,
+		userID,
+		now,
+	)
+	if err != nil {
+		return nil, err
+	}
+	revoked := make([]RevokedVerificationSnapshot, 0, 4)
+	for rows.Next() {
+		var snap RevokedVerificationSnapshot
+		if err = rows.Scan(&snap.ID, &snap.ExpiresAt); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		revoked = append(revoked, snap)
+	}
+	rows.Close()
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
 	if _, err = tx.Exec(ctx, `
 update email_verifications
 set expires_at = $2
@@ -208,7 +243,7 @@ where user_id = $1
 		return nil, err
 	}
 
-	emailRecordID, err := createVerificationTx(ctx, tx, CreateVerificationParams{
+	created, err := createVerificationWithIDsTx(ctx, tx, CreateVerificationParams{
 		UserID:     userID,
 		OTP:        otp,
 		MagicToken: magicToken,
@@ -222,10 +257,70 @@ where user_id = $1
 		return nil, err
 	}
 	return &ResendVerificationResult{
-		UserID:        userID,
-		UserEmail:     userEmail,
-		EmailRecordID: emailRecordID,
+		UserID:               userID,
+		UserEmail:            userEmail,
+		EmailRecordID:        created.EmailRecordID,
+		OTPVerificationID:    created.OTPVerificationID,
+		MagicVerificationID:  created.MagicVerificationID,
+		RevokedVerifications: revoked,
 	}, nil
+}
+
+func (s *Store) RollbackResendVerification(ctx context.Context, resend *ResendVerificationResult) error {
+	if resend == nil {
+		return nil
+	}
+	tx, err := s.DB.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if rbErr := tx.Rollback(ctx); rbErr != nil && !errors.Is(rbErr, pgx.ErrTxClosed) {
+			_ = rbErr
+		}
+	}()
+
+	verificationIDs := []string{resend.OTPVerificationID, resend.MagicVerificationID}
+	if _, err = tx.Exec(ctx, `
+delete from email_verifications
+where user_id = $1
+  and verified_at is null
+  and id = any($2)`,
+		resend.UserID,
+		verificationIDs,
+	); err != nil {
+		return err
+	}
+
+	if _, err = tx.Exec(ctx, `
+delete from email_records
+where id = $1
+  and user_id = $2`,
+		resend.EmailRecordID,
+		resend.UserID,
+	); err != nil {
+		return err
+	}
+
+	rollbackAt := time.Now()
+	for _, snap := range resend.RevokedVerifications {
+		if _, err = tx.Exec(ctx, `
+update email_verifications
+set expires_at = $2
+where id = $1
+  and user_id = $3
+  and verified_at is null
+  and expires_at <= $4`,
+			snap.ID,
+			snap.ExpiresAt,
+			resend.UserID,
+			rollbackAt,
+		); err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit(ctx)
 }
 
 func (s *Store) VerifyEmailOTP(ctx context.Context, emailAddr, otp string, now time.Time) error {
@@ -577,33 +672,49 @@ func insertRegisteredUserWithPassword(ctx context.Context, tx pgx.Tx, userID, em
 	return nil
 }
 
+type createVerificationTxResult struct {
+	EmailRecordID       string
+	OTPVerificationID   string
+	MagicVerificationID string
+}
+
 func createVerificationTx(ctx context.Context, tx pgx.Tx, params CreateVerificationParams) (string, error) {
+	res, err := createVerificationWithIDsTx(ctx, tx, params)
+	if err != nil {
+		return "", err
+	}
+	return res.EmailRecordID, nil
+}
+
+func createVerificationWithIDsTx(ctx context.Context, tx pgx.Tx, params CreateVerificationParams) (*createVerificationTxResult, error) {
 	var recipientEmail string
 	if err := tx.QueryRow(ctx, `select email from users where id=$1`, params.UserID).Scan(&recipientEmail); err != nil {
-		return "", err
+		return nil, err
 	}
 
 	otpHash := email.HashToken(params.OTP)
 	magicLinkHash := email.HashToken(params.MagicToken)
+	otpVerificationID := uuid.NewString()
 	if _, err := tx.Exec(
 		ctx,
 		`insert into email_verifications(id,user_id,token_hash,token_type,expires_at,created_at) values($1,$2,$3,'otp',$4,now())`,
-		uuid.NewString(),
+		otpVerificationID,
 		params.UserID,
 		otpHash,
 		params.ExpiresAt,
 	); err != nil {
-		return "", err
+		return nil, err
 	}
+	magicVerificationID := uuid.NewString()
 	if _, err := tx.Exec(
 		ctx,
 		`insert into email_verifications(id,user_id,token_hash,token_type,expires_at,created_at) values($1,$2,$3,'magic_link',$4,now())`,
-		uuid.NewString(),
+		magicVerificationID,
 		params.UserID,
 		magicLinkHash,
 		params.ExpiresAt,
 	); err != nil {
-		return "", err
+		return nil, err
 	}
 
 	emailRecordID := uuid.NewString()
@@ -614,7 +725,11 @@ func createVerificationTx(ctx context.Context, tx pgx.Tx, params CreateVerificat
 		params.UserID,
 		recipientEmail,
 	); err != nil {
-		return "", err
+		return nil, err
 	}
-	return emailRecordID, nil
+	return &createVerificationTxResult{
+		EmailRecordID:       emailRecordID,
+		OTPVerificationID:   otpVerificationID,
+		MagicVerificationID: magicVerificationID,
+	}, nil
 }

--- a/services/auth-api/internal/store/store.go
+++ b/services/auth-api/internal/store/store.go
@@ -29,6 +29,8 @@ var (
 	ErrVerificationExpired       = errors.New("verification_expired")
 	ErrTooManyOTPAttempts        = errors.New("too_many_otp_attempts")
 	ErrPendingRegistrationGone   = errors.New("pending_registration_not_found")
+	ErrResendUserNotFound        = errors.New("resend_user_not_found")
+	ErrResendAlreadyVerified     = errors.New("resend_already_verified")
 )
 
 const maxOTPVerificationAttempts = 5
@@ -58,6 +60,12 @@ type CreateVerificationResult struct {
 
 type RegisterWithVerificationResult struct {
 	User          RegisteredUser
+	EmailRecordID string
+}
+
+type ResendVerificationResult struct {
+	UserID        string
+	UserEmail     string
 	EmailRecordID string
 }
 
@@ -149,6 +157,75 @@ func (s *Store) CreateVerification(ctx context.Context, params CreateVerificatio
 		return nil, err
 	}
 	return &CreateVerificationResult{EmailRecordID: emailRecordID}, nil
+}
+
+func (s *Store) ResendVerification(
+	ctx context.Context,
+	emailAddr, otp, magicToken string,
+	expiresAt, now time.Time,
+) (*ResendVerificationResult, error) {
+	tx, err := s.DB.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if rbErr := tx.Rollback(ctx); rbErr != nil && !errors.Is(rbErr, pgx.ErrTxClosed) {
+			_ = rbErr
+		}
+	}()
+
+	var (
+		userID          string
+		userEmail       string
+		emailVerifiedAt *time.Time
+	)
+	err = tx.QueryRow(ctx, `
+select id, email, email_verified_at
+from users
+where email = $1
+for update`,
+		emailAddr,
+	).Scan(&userID, &userEmail, &emailVerifiedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrResendUserNotFound
+		}
+		return nil, err
+	}
+	if emailVerifiedAt != nil {
+		return nil, ErrResendAlreadyVerified
+	}
+
+	if _, err = tx.Exec(ctx, `
+update email_verifications
+set expires_at = $2
+where user_id = $1
+  and verified_at is null
+  and expires_at > $2`,
+		userID,
+		now,
+	); err != nil {
+		return nil, err
+	}
+
+	emailRecordID, err := createVerificationTx(ctx, tx, CreateVerificationParams{
+		UserID:     userID,
+		OTP:        otp,
+		MagicToken: magicToken,
+		ExpiresAt:  expiresAt,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if err = tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+	return &ResendVerificationResult{
+		UserID:        userID,
+		UserEmail:     userEmail,
+		EmailRecordID: emailRecordID,
+	}, nil
 }
 
 func (s *Store) VerifyEmailOTP(ctx context.Context, emailAddr, otp string, now time.Time) error {

--- a/services/auth-api/internal/store/store.go
+++ b/services/auth-api/internal/store/store.go
@@ -74,6 +74,7 @@ type ResendVerificationResult struct {
 	EmailRecordID        string
 	OTPVerificationID    string
 	MagicVerificationID  string
+	RevokedAt            time.Time
 	RevokedVerifications []RevokedVerificationSnapshot
 }
 
@@ -262,6 +263,7 @@ where user_id = $1
 		EmailRecordID:        created.EmailRecordID,
 		OTPVerificationID:    created.OTPVerificationID,
 		MagicVerificationID:  created.MagicVerificationID,
+		RevokedAt:            now,
 		RevokedVerifications: revoked,
 	}, nil
 }
@@ -302,7 +304,10 @@ where id = $1
 		return err
 	}
 
-	rollbackAt := time.Now()
+	rollbackAt := resend.RevokedAt
+	if rollbackAt.IsZero() {
+		rollbackAt = time.Now()
+	}
 	for _, snap := range resend.RevokedVerifications {
 		if _, err = tx.Exec(ctx, `
 update email_verifications

--- a/services/auth-api/internal/store/store_authn_test.go
+++ b/services/auth-api/internal/store/store_authn_test.go
@@ -141,6 +141,96 @@ where token_type='otp' and token_hash=$1`, otpHash).Scan(&otpCount); err != nil 
 	}
 }
 
+func TestStoreRollbackResendVerificationRestoresPreviousVerificationRows(t *testing.T) {
+	db := testutil.MustTestDB(t)
+	testutil.TruncateAuthTables(t, db)
+
+	s := &Store{DB: db}
+	userID := "store-resend-rollback-user"
+	emailAddr := "store-resend-rollback@example.com"
+	seedStoreUser(t, db, userID, emailAddr)
+
+	oldExpiresAt := time.Now().Add(10 * time.Minute).Round(time.Second)
+	oldOTPID := "store-resend-old-otp"
+	oldMagicID := "store-resend-old-magic"
+	if _, err := db.Exec(context.Background(), `
+insert into email_verifications(id,user_id,token_hash,token_type,expires_at,created_at)
+values($1,$2,$3,'otp',$4,now()-interval '3 minutes')`,
+		oldOTPID,
+		userID,
+		commonemail.HashToken("111111"),
+		oldExpiresAt,
+	); err != nil {
+		t.Fatalf("insert old otp verification: %v", err)
+	}
+	if _, err := db.Exec(context.Background(), `
+insert into email_verifications(id,user_id,token_hash,token_type,expires_at,created_at)
+values($1,$2,$3,'magic_link',$4,now()-interval '3 minutes')`,
+		oldMagicID,
+		userID,
+		commonemail.HashToken("old-magic-token"),
+		oldExpiresAt,
+	); err != nil {
+		t.Fatalf("insert old magic verification: %v", err)
+	}
+
+	now := time.Now().Round(time.Second)
+	ctx, cancel := testCtx(t)
+	defer cancel()
+	resend, err := s.ResendVerification(ctx, emailAddr, "222222", "new-magic-token", now.Add(15*time.Minute), now)
+	if err != nil {
+		t.Fatalf("ResendVerification: %v", err)
+	}
+	if resend == nil || resend.EmailRecordID == "" || resend.OTPVerificationID == "" || resend.MagicVerificationID == "" {
+		t.Fatalf("unexpected resend result: %+v", resend)
+	}
+	if len(resend.RevokedVerifications) != 2 {
+		t.Fatalf("revoked verification count=%d want=2", len(resend.RevokedVerifications))
+	}
+
+	ctxRollback, cancelRollback := testCtx(t)
+	defer cancelRollback()
+	if err := s.RollbackResendVerification(ctxRollback, resend); err != nil {
+		t.Fatalf("RollbackResendVerification: %v", err)
+	}
+
+	var deletedCount int
+	if err := db.QueryRow(context.Background(), `
+select count(1)
+from email_verifications
+where user_id=$1 and id = any($2)`,
+		userID,
+		[]string{resend.OTPVerificationID, resend.MagicVerificationID},
+	).Scan(&deletedCount); err != nil {
+		t.Fatalf("query new verification rows: %v", err)
+	}
+	if deletedCount != 0 {
+		t.Fatalf("new verification rows remaining=%d want=0", deletedCount)
+	}
+
+	var restoredOTPExpiry, restoredMagicExpiry time.Time
+	if err := db.QueryRow(context.Background(), `select expires_at from email_verifications where id=$1`, oldOTPID).Scan(&restoredOTPExpiry); err != nil {
+		t.Fatalf("query restored old otp expiry: %v", err)
+	}
+	if err := db.QueryRow(context.Background(), `select expires_at from email_verifications where id=$1`, oldMagicID).Scan(&restoredMagicExpiry); err != nil {
+		t.Fatalf("query restored old magic expiry: %v", err)
+	}
+	if !restoredOTPExpiry.Round(time.Second).Equal(oldExpiresAt) {
+		t.Fatalf("old otp expires_at=%s want=%s", restoredOTPExpiry, oldExpiresAt)
+	}
+	if !restoredMagicExpiry.Round(time.Second).Equal(oldExpiresAt) {
+		t.Fatalf("old magic expires_at=%s want=%s", restoredMagicExpiry, oldExpiresAt)
+	}
+
+	var emailRecordCount int
+	if err := db.QueryRow(context.Background(), `select count(1) from email_records where id=$1`, resend.EmailRecordID).Scan(&emailRecordCount); err != nil {
+		t.Fatalf("query resend email record: %v", err)
+	}
+	if emailRecordCount != 0 {
+		t.Fatalf("resend email record count=%d want=0", emailRecordCount)
+	}
+}
+
 func TestStoreVerifyEmailOTPPromotesPendingUser(t *testing.T) {
 	db := testutil.MustTestDB(t)
 	testutil.TruncateAuthTables(t, db)


### PR DESCRIPTION
## Summary
- add `POST /api/v1/auth/resend-verification` and DTOs for request/response envelope data
- implement resend verification flow with Redis per-email limiter (`resend:{email}`), strict 90s cooldown, and max-6 window guard
- validate resend eligibility (user exists and `email_verified_at IS NULL`), revoke prior unverified verification tokens, issue new OTP + magic-link tokens, enqueue email job, and return `202` with `retry_after`
- add handler tests for success, cooldown/over-limit rate limiting, and verified-user rejection
- update Postman collection with resend-verification request

Closes #80

## Issue #80 Checklist
- [x] Redis rate limiting: key `resend:{email}`, 90-second window, max 6
- [x] Validate user exists and `users.email_verified_at IS NULL`
- [x] Revoke old unverified tokens safely
- [x] Generate new OTP and Magic Link token
- [x] Enqueue email job
- [x] Return `202 Accepted` + `retry_after`
- [x] Return `429 Too Many Requests` when rate-limited
- [x] Update Postman collection

## Acceptance Criteria
- [x] User receives a new email after successful resend
- [x] Resend within 90 seconds returns 429
- [x] More than 6 resends returns 429
- [x] Verified user resend returns 400
- [x] Unit tests cover success / rate limit / verified user

## Tests Executed
- `go test ./services/auth-api/internal/handler -run ResendVerification -v -count=1`
- `go test ./services/auth-api/...`
- `go test ./...`

> Note: integration-style handler tests are environment-gated by `TEST_DB_DSN` and `TEST_REDIS_ADDR`; in this environment those vars are unset, so those cases are reported as skipped by the test harness.