### PR TITLE
email-worker: add bounce classification, soft-retry scheduling and blacklist with DB migration

### DIFF
--- a/services/auth-api/internal/testutil/testenv.go
+++ b/services/auth-api/internal/testutil/testenv.go
@@ -97,7 +97,7 @@ func MustJWTSecret(t *testing.T) string {
 
 func ApplyMigrations(t *testing.T, db *pgxpool.Pool) {
 	t.Helper()
-	for _, name := range []string{"001_init.sql", "002_authn_core.sql", "003_multitenant.sql", "004_email_service.sql", "005_email_verifications_token_hash_scope.sql"} {
+	for _, name := range []string{"001_init.sql", "002_authn_core.sql", "003_multitenant.sql", "004_email_service.sql", "005_email_verifications_token_hash_scope.sql", "006_email_blacklist.sql"} {
 		sqlPath := filepath.Join(migrationsDir(t), name)
 		sqlBytes, err := os.ReadFile(sqlPath)
 		if err != nil {

--- a/services/auth-api/migrations/006_email_blacklist.sql
+++ b/services/auth-api/migrations/006_email_blacklist.sql
@@ -1,0 +1,12 @@
+-- M6-02: email bounce blacklist
+
+create table if not exists email_blacklist (
+  id text primary key,
+  email text not null unique,
+  reason text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_email_blacklist_email
+  on email_blacklist(email);

--- a/services/email-worker/internal/consumer/consumer.go
+++ b/services/email-worker/internal/consumer/consumer.go
@@ -17,25 +17,29 @@ import (
 )
 
 var (
-	ErrNilQueue     = errors.New("nil_queue")
-	ErrNilSender    = errors.New("nil_sender")
-	ErrNilStore     = errors.New("nil_store")
-	ErrEmptyQueue   = errors.New("empty_queue_name")
-	ErrInvalidJob   = errors.New("invalid_email_job")
-	ErrEmptyRecord  = errors.New("empty_record_id")
-	ErrEmptyToEmail = errors.New("empty_to_email")
-	ErrEmptyOTP     = errors.New("empty_otp")
-	ErrEmptyMagic   = errors.New("empty_magic_link")
-	ErrEmptyExpiry  = errors.New("empty_expires_in")
+	ErrNilQueue           = errors.New("nil_queue")
+	ErrNilSender          = errors.New("nil_sender")
+	ErrNilStore           = errors.New("nil_store")
+	ErrEmptyQueue         = errors.New("empty_queue_name")
+	ErrInvalidJob         = errors.New("invalid_email_job")
+	ErrEmptyRecord        = errors.New("empty_record_id")
+	ErrEmptyToEmail       = errors.New("empty_to_email")
+	ErrEmptyOTP           = errors.New("empty_otp")
+	ErrEmptyMagic         = errors.New("empty_magic_link")
+	ErrEmptyExpiry        = errors.New("empty_expires_in")
+	ErrEmailBlacklisted   = errors.New("email_blacklisted")
+	ErrSoftBounceExceeded = errors.New("soft_bounce_retry_exhausted")
 )
 
 var (
 	verificationHTMLTemplate = htmltemplate.Must(htmltemplate.ParseFS(emailtemplates.FS, "verification_email.html.tmpl"))
 	verificationTextTemplate = texttemplate.Must(texttemplate.ParseFS(emailtemplates.FS, "verification_email.txt.tmpl"))
+	softBounceRetryIntervals = []time.Duration{time.Hour, 4 * time.Hour, 24 * time.Hour}
 )
 
 type Queue interface {
 	DequeueIntoContext(ctx context.Context, queueName string, timeout time.Duration, out any) (bool, error)
+	EnqueueContext(ctx context.Context, queueName string, payload any) error
 }
 
 type Sender interface {
@@ -45,17 +49,31 @@ type Sender interface {
 type Store interface {
 	MarkSent(ctx context.Context, recordID, externalID string) error
 	MarkFailed(ctx context.Context, recordID, reason string) error
+	MarkBounced(ctx context.Context, recordID, reason, bounceType string, smtpCode, retryCount int) error
+	Blacklist(ctx context.Context, emailAddr, reason string) error
+	IsBlacklisted(ctx context.Context, emailAddr string) (bool, error)
+}
+
+type Scheduler interface {
+	AfterFunc(d time.Duration, f func())
+}
+
+type realScheduler struct{}
+
+func (realScheduler) AfterFunc(d time.Duration, f func()) {
+	time.AfterFunc(d, f)
 }
 
 type EmailJob struct {
-	RecordID  string `json:"record_id"`
-	To        string `json:"to"`
-	Subject   string `json:"subject"`
-	HTMLBody  string `json:"html_body"`
-	TextBody  string `json:"text_body"`
-	OTP       string `json:"otp"`
-	MagicLink string `json:"magic_link"`
-	ExpiresIn string `json:"expires_in"`
+	RecordID   string `json:"record_id"`
+	To         string `json:"to"`
+	Subject    string `json:"subject"`
+	HTMLBody   string `json:"html_body"`
+	TextBody   string `json:"text_body"`
+	OTP        string `json:"otp"`
+	MagicLink  string `json:"magic_link"`
+	ExpiresIn  string `json:"expires_in"`
+	RetryCount int    `json:"retry_count,omitempty"`
 }
 
 type Consumer struct {
@@ -64,6 +82,7 @@ type Consumer struct {
 	Timeout   time.Duration
 	Sender    Sender
 	Store     Store
+	Scheduler Scheduler
 }
 
 func (c *Consumer) Run(ctx context.Context) error {
@@ -81,6 +100,9 @@ func (c *Consumer) Run(ctx context.Context) error {
 	}
 	if c.Timeout <= 0 {
 		c.Timeout = 5 * time.Second
+	}
+	if c.Scheduler == nil {
+		c.Scheduler = realScheduler{}
 	}
 
 	for {
@@ -121,6 +143,17 @@ func (c *Consumer) handleJob(ctx context.Context, job EmailJob) error {
 		}
 		return errors.New(reason)
 	}
+	isBlacklisted, err := c.Store.IsBlacklisted(ctx, job.To)
+	if err != nil {
+		return err
+	}
+	if isBlacklisted {
+		reason := ErrEmailBlacklisted.Error()
+		if markErr := c.Store.MarkFailed(ctx, job.RecordID, reason); markErr != nil {
+			return fmt.Errorf("%s; mark failed: %v", reason, markErr)
+		}
+		return ErrEmailBlacklisted
+	}
 
 	htmlBody := job.HTMLBody
 	textBody := job.TextBody
@@ -137,17 +170,9 @@ func (c *Consumer) handleJob(ctx context.Context, job EmailJob) error {
 		textBody = renderedText
 	}
 
-	externalID, err := c.Sender.Send(ctx, sender.Request{
-		To:       job.To,
-		Subject:  job.Subject,
-		HTMLBody: htmlBody,
-		TextBody: textBody,
-	})
+	externalID, err := c.Sender.Send(ctx, sender.Request{To: job.To, Subject: job.Subject, HTMLBody: htmlBody, TextBody: textBody})
 	if err != nil {
-		if markErr := c.Store.MarkFailed(ctx, job.RecordID, err.Error()); markErr != nil {
-			return fmt.Errorf("send email: %w; mark failed: %v", err, markErr)
-		}
-		return err
+		return c.handleDeliveryError(ctx, job, err)
 	}
 
 	if err := c.Store.MarkSent(ctx, job.RecordID, externalID); err != nil {
@@ -155,6 +180,52 @@ func (c *Consumer) handleJob(ctx context.Context, job EmailJob) error {
 	}
 
 	return nil
+}
+
+func (c *Consumer) handleDeliveryError(ctx context.Context, job EmailJob, sendErr error) error {
+	var deliveryErr *sender.DeliveryError
+	if !errors.As(sendErr, &deliveryErr) || deliveryErr.Classification.Type == sender.BounceTypeNone {
+		if markErr := c.Store.MarkFailed(ctx, job.RecordID, sendErr.Error()); markErr != nil {
+			return fmt.Errorf("send email: %w; mark failed: %v", sendErr, markErr)
+		}
+		return sendErr
+	}
+
+	smtpCode := deliveryErr.Classification.SMTPCode
+	switch deliveryErr.Classification.Type {
+	case sender.BounceTypeHard:
+		if err := c.Store.MarkBounced(ctx, job.RecordID, sendErr.Error(), string(sender.BounceTypeHard), smtpCode, job.RetryCount); err != nil {
+			return err
+		}
+		if err := c.Store.Blacklist(ctx, job.To, sendErr.Error()); err != nil {
+			return err
+		}
+		return sendErr
+	case sender.BounceTypeSoft:
+		if err := c.Store.MarkBounced(ctx, job.RecordID, sendErr.Error(), string(sender.BounceTypeSoft), smtpCode, job.RetryCount); err != nil {
+			return err
+		}
+		if job.RetryCount >= len(softBounceRetryIntervals) {
+			if err := c.Store.MarkFailed(ctx, job.RecordID, ErrSoftBounceExceeded.Error()); err != nil {
+				return err
+			}
+			return ErrSoftBounceExceeded
+		}
+		delay := softBounceRetryIntervals[job.RetryCount]
+		retryJob := job
+		retryJob.RetryCount++
+		c.Scheduler.AfterFunc(delay, func() {
+			if err := c.Queue.EnqueueContext(context.Background(), c.QueueName, retryJob); err != nil {
+				log.Printf("email-worker: failed to enqueue soft-bounce retry record_id=%q: %v", job.RecordID, err)
+			}
+		})
+		return sendErr
+	default:
+		if markErr := c.Store.MarkFailed(ctx, job.RecordID, sendErr.Error()); markErr != nil {
+			return fmt.Errorf("send email: %w; mark failed: %v", sendErr, markErr)
+		}
+		return sendErr
+	}
 }
 
 func renderVerificationEmailBody(job EmailJob) (string, string, error) {
@@ -171,11 +242,7 @@ func renderVerificationEmailBody(job EmailJob) (string, string, error) {
 		OTP       string
 		MagicLink string
 		ExpiresIn string
-	}{
-		OTP:       job.OTP,
-		MagicLink: job.MagicLink,
-		ExpiresIn: job.ExpiresIn,
-	}
+	}{OTP: job.OTP, MagicLink: job.MagicLink, ExpiresIn: job.ExpiresIn}
 
 	var htmlBody bytes.Buffer
 	if err := verificationHTMLTemplate.Execute(&htmlBody, data); err != nil {

--- a/services/email-worker/internal/consumer/consumer_test.go
+++ b/services/email-worker/internal/consumer/consumer_test.go
@@ -24,6 +24,7 @@ type fakeQueue struct {
 	mu       sync.Mutex
 	resps    []queueResp
 	timeouts []time.Duration
+	enqueued []EmailJob
 }
 
 func (q *fakeQueue) DequeueIntoContext(ctx context.Context, queueName string, timeout time.Duration, out any) (bool, error) {
@@ -51,6 +52,17 @@ func (q *fakeQueue) DequeueIntoContext(ctx context.Context, queueName string, ti
 	return false, ctx.Err()
 }
 
+func (q *fakeQueue) EnqueueContext(_ context.Context, _ string, payload any) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	job, ok := payload.(EmailJob)
+	if !ok {
+		return errors.New("unexpected payload type")
+	}
+	q.enqueued = append(q.enqueued, job)
+	return nil
+}
+
 type senderResp struct {
 	externalID string
 	err        error
@@ -75,9 +87,14 @@ func (s *fakeSender) Send(_ context.Context, req sender.Request) (string, error)
 }
 
 type fakeStore struct {
-	mu           sync.Mutex
-	sent         []struct{ recordID, externalID string }
-	failed       []struct{ recordID, reason string }
+	mu      sync.Mutex
+	sent    []struct{ recordID, externalID string }
+	failed  []struct{ recordID, reason string }
+	bounced []struct {
+		recordID, reason, bounceType string
+		smtpCode, retryCount         int
+	}
+	blacklisted  map[string]bool
 	markSentErr  error
 	markFailErr  error
 	onMarkSent   func()
@@ -106,6 +123,35 @@ func (s *fakeStore) MarkFailed(_ context.Context, recordID, reason string) error
 		cb()
 	}
 	return err
+}
+
+func (s *fakeStore) MarkBounced(_ context.Context, recordID, reason, bounceType string, smtpCode, retryCount int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.bounced = append(s.bounced, struct {
+		recordID, reason, bounceType string
+		smtpCode, retryCount         int
+	}{recordID: recordID, reason: reason, bounceType: bounceType, smtpCode: smtpCode, retryCount: retryCount})
+	return nil
+}
+
+func (s *fakeStore) Blacklist(_ context.Context, emailAddr, _ string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.blacklisted == nil {
+		s.blacklisted = map[string]bool{}
+	}
+	s.blacklisted[strings.ToLower(strings.TrimSpace(emailAddr))] = true
+	return nil
+}
+
+func (s *fakeStore) IsBlacklisted(_ context.Context, emailAddr string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.blacklisted == nil {
+		return false, nil
+	}
+	return s.blacklisted[strings.ToLower(strings.TrimSpace(emailAddr))], nil
 }
 
 func TestRun_DefaultTimeoutAndSuccessPath(t *testing.T) {
@@ -492,5 +538,96 @@ func TestRun_WithRedisQueue_InvalidJSONDroppedThenProcessesNextJob(t *testing.T)
 	}
 	if len(st.sent) != 1 || st.sent[0].recordID != "rec-redis-2" {
 		t.Fatalf("sent=%+v want record_id=rec-redis-2", st.sent)
+	}
+}
+
+type fakeScheduler struct {
+	delays  []time.Duration
+	autoRun bool
+}
+
+func (s *fakeScheduler) AfterFunc(d time.Duration, f func()) {
+	s.delays = append(s.delays, d)
+	if s.autoRun {
+		f()
+	}
+}
+
+func TestRun_HardBounceBlacklistsAndNoRetry(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	q := &fakeQueue{resps: []queueResp{{ok: true, job: EmailJob{RecordID: "rec-hard", To: "user@example.com", HTMLBody: "<p>h</p>", TextBody: "h"}}}}
+	s := &fakeSender{resps: []senderResp{{err: &sender.DeliveryError{Cause: errors.New("550 mailbox unavailable"), Classification: sender.BounceClassification{Type: sender.BounceTypeHard, SMTPCode: 550}}}}}
+	st := &fakeStore{}
+
+	c := &Consumer{Queue: q, QueueName: "email:send", Timeout: time.Second, Sender: s, Store: st, Scheduler: &fakeScheduler{autoRun: true}}
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+	_ = c.Run(ctx)
+
+	if len(st.bounced) != 1 || st.bounced[0].bounceType != "hard" || st.bounced[0].smtpCode != 550 {
+		t.Fatalf("unexpected bounced=%+v", st.bounced)
+	}
+	if !st.blacklisted["user@example.com"] {
+		t.Fatalf("expected address blacklisted: %+v", st.blacklisted)
+	}
+	if len(q.enqueued) != 0 {
+		t.Fatalf("unexpected retries enqueued=%d", len(q.enqueued))
+	}
+}
+
+func TestRun_SoftBounceRetriesWithExpectedIntervals(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	q := &fakeQueue{resps: []queueResp{{ok: true, job: EmailJob{RecordID: "rec-soft", To: "user@example.com", HTMLBody: "<p>h</p>", TextBody: "h"}}}}
+	s := &fakeSender{resps: []senderResp{{err: &sender.DeliveryError{Cause: errors.New("451 mailbox busy"), Classification: sender.BounceClassification{Type: sender.BounceTypeSoft, SMTPCode: 451}}}}}
+	st := &fakeStore{}
+	sch := &fakeScheduler{autoRun: true}
+
+	c := &Consumer{Queue: q, QueueName: "email:send", Timeout: time.Second, Sender: s, Store: st, Scheduler: sch}
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+	_ = c.Run(ctx)
+
+	if len(st.bounced) != 1 || st.bounced[0].bounceType != "soft" {
+		t.Fatalf("unexpected bounced=%+v", st.bounced)
+	}
+	if len(sch.delays) != 1 || sch.delays[0] != time.Hour {
+		t.Fatalf("delays=%v want=[1h]", sch.delays)
+	}
+	if len(q.enqueued) != 1 || q.enqueued[0].RetryCount != 1 {
+		t.Fatalf("enqueued=%+v want retry_count=1", q.enqueued)
+	}
+}
+
+func TestHandleDeliveryError_SoftBounceRetryExhaustedAfterThreeRetries(t *testing.T) {
+	c := &Consumer{Store: &fakeStore{}, Queue: &fakeQueue{}, QueueName: "email:send", Scheduler: &fakeScheduler{}}
+	err := c.handleDeliveryError(context.Background(), EmailJob{RecordID: "rec-soft-exhausted", To: "user@example.com", RetryCount: 3}, &sender.DeliveryError{Cause: errors.New("451 mailbox busy"), Classification: sender.BounceClassification{Type: sender.BounceTypeSoft, SMTPCode: 451}})
+	if !errors.Is(err, ErrSoftBounceExceeded) {
+		t.Fatalf("err=%v want=%v", err, ErrSoftBounceExceeded)
+	}
+}
+
+func TestRun_BlacklistedRecipientIsNotSent(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	q := &fakeQueue{resps: []queueResp{{ok: true, job: EmailJob{RecordID: "rec-bl", To: "user@example.com", HTMLBody: "<p>h</p>", TextBody: "h"}}}}
+	s := &fakeSender{}
+	st := &fakeStore{blacklisted: map[string]bool{"user@example.com": true}, onMarkFailed: cancel}
+	c := &Consumer{Queue: q, QueueName: "email:send", Timeout: time.Second, Sender: s, Store: st}
+	_ = c.Run(ctx)
+
+	if len(s.requests) != 0 {
+		t.Fatalf("send requests=%d want=0", len(s.requests))
+	}
+	if len(st.failed) != 1 || st.failed[0].reason != ErrEmailBlacklisted.Error() {
+		t.Fatalf("failed=%+v", st.failed)
 	}
 }

--- a/services/email-worker/internal/sender/bounce.go
+++ b/services/email-worker/internal/sender/bounce.go
@@ -1,0 +1,59 @@
+package sender
+
+import (
+	"errors"
+	"net/textproto"
+	"regexp"
+	"strconv"
+)
+
+type BounceType string
+
+const (
+	BounceTypeNone BounceType = ""
+	BounceTypeSoft BounceType = "soft"
+	BounceTypeHard BounceType = "hard"
+)
+
+type BounceClassification struct {
+	Type     BounceType
+	SMTPCode int
+}
+
+var smtpCodeRegexp = regexp.MustCompile(`\b([45][0-9]{2})\b`)
+
+func ClassifySMTPError(err error) BounceClassification {
+	if err == nil {
+		return BounceClassification{}
+	}
+
+	var protoErr *textproto.Error
+	if errors.As(err, &protoErr) {
+		return classifySMTPCode(protoErr.Code)
+	}
+
+	matches := smtpCodeRegexp.FindStringSubmatch(err.Error())
+	if len(matches) != 2 {
+		return BounceClassification{}
+	}
+
+	code, convErr := strconv.Atoi(matches[1])
+	if convErr != nil {
+		return BounceClassification{}
+	}
+
+	return classifySMTPCode(code)
+}
+
+func classifySMTPCode(code int) BounceClassification {
+	classification := BounceClassification{SMTPCode: code}
+	switch {
+	case code >= 400 && code < 500:
+		classification.Type = BounceTypeSoft
+	case code >= 500 && code < 600:
+		classification.Type = BounceTypeHard
+	default:
+		classification.Type = BounceTypeNone
+	}
+	return classification
+}

--- a/services/email-worker/internal/sender/bounce_test.go
+++ b/services/email-worker/internal/sender/bounce_test.go
@@ -1,0 +1,29 @@
+package sender
+
+import (
+	"errors"
+	"net/textproto"
+	"testing"
+)
+
+func TestClassifySMTPError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantType BounceType
+		wantCode int
+	}{
+		{name: "hard via textproto", err: &textproto.Error{Code: 550, Msg: "mailbox unavailable"}, wantType: BounceTypeHard, wantCode: 550},
+		{name: "soft via message", err: errors.New("451 temporary local problem"), wantType: BounceTypeSoft, wantCode: 451},
+		{name: "not smtp", err: errors.New("connection reset by peer"), wantType: BounceTypeNone, wantCode: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ClassifySMTPError(tt.err)
+			if got.Type != tt.wantType || got.SMTPCode != tt.wantCode {
+				t.Fatalf("classification=%+v want type=%q code=%d", got, tt.wantType, tt.wantCode)
+			}
+		})
+	}
+}

--- a/services/email-worker/internal/sender/sender.go
+++ b/services/email-worker/internal/sender/sender.go
@@ -3,6 +3,7 @@ package sender
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/google/uuid"
@@ -23,6 +24,28 @@ type smtpClient interface {
 	SendEmail(to, subject, htmlBody, textBody string) error
 }
 
+type DeliveryError struct {
+	Cause          error
+	Classification BounceClassification
+}
+
+func (e *DeliveryError) Error() string {
+	if e == nil || e.Cause == nil {
+		return "delivery_error"
+	}
+	if e.Classification.Type == BounceTypeNone {
+		return e.Cause.Error()
+	}
+	return fmt.Sprintf("%s (bounce=%s code=%d)", e.Cause.Error(), e.Classification.Type, e.Classification.SMTPCode)
+}
+
+func (e *DeliveryError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}
+
 type Sender struct {
 	smtp smtpClient
 }
@@ -40,12 +63,10 @@ func (s *Sender) Send(ctx context.Context, req Request) (string, error) {
 	}
 	smtpClient := s.smtp
 	if smtpClient == nil {
-		// Preserve historical zero-value Sender behavior: return SMTP config validation
-		// errors instead of panicking when Sender is constructed directly.
 		smtpClient = email.SMTPConfig{}
 	}
 	if err := smtpClient.SendEmail(req.To, req.Subject, req.HTMLBody, req.TextBody); err != nil {
-		return "", err
+		return "", &DeliveryError{Cause: err, Classification: ClassifySMTPError(err)}
 	}
 	return uuid.NewString(), nil
 }

--- a/services/email-worker/internal/sender/sender_test.go
+++ b/services/email-worker/internal/sender/sender_test.go
@@ -91,8 +91,15 @@ func TestSend_SMTPError(t *testing.T) {
 		To:      "user@example.com",
 		Subject: "Subject",
 	})
-	if err == nil || err.Error() != "smtp rejected message" {
-		t.Fatalf("err=%v want=%q", err, "smtp rejected message")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var deliveryErr *DeliveryError
+	if !errors.As(err, &deliveryErr) {
+		t.Fatalf("err=%T want *DeliveryError", err)
+	}
+	if !errors.Is(err, smtp.err) {
+		t.Fatalf("err should unwrap smtp err: %v", err)
 	}
 	if id != "" {
 		t.Fatalf("id=%q want empty", id)

--- a/services/email-worker/internal/store/store.go
+++ b/services/email-worker/internal/store/store.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 
@@ -15,6 +16,7 @@ var (
 	ErrEmailRecordNotFound = errors.New("email_record_not_found")
 	ErrEmptyRecordID       = errors.New("empty_record_id")
 	ErrEmptyExternalID     = errors.New("empty_external_id")
+	ErrEmptyEmail          = errors.New("empty_email")
 )
 
 type Store struct {
@@ -36,16 +38,9 @@ func (s *Store) MarkSent(ctx context.Context, recordID, externalID string) error
 	if err != nil {
 		return err
 	}
-	defer func() {
-		_ = tx.Rollback(ctx)
-	}()
+	defer func() { _ = tx.Rollback(ctx) }()
 
-	ct, err := tx.Exec(
-		ctx,
-		`update email_records set external_id=$2, status='sent', updated_at=now() where id=$1`,
-		recordID,
-		externalID,
-	)
+	ct, err := tx.Exec(ctx, `update email_records set external_id=$2, status='sent', updated_at=now() where id=$1`, recordID, externalID)
 	if err != nil {
 		return err
 	}
@@ -53,17 +48,9 @@ func (s *Store) MarkSent(ctx context.Context, recordID, externalID string) error
 		return ErrEmailRecordNotFound
 	}
 
-	if _, err := tx.Exec(
-		ctx,
-		`insert into email_status_history(id,email_record_id,status,message,meta,created_at) values($1,$2,$3,$4,null,now())`,
-		uuid.NewString(),
-		recordID,
-		"sent",
-		"email sent successfully",
-	); err != nil {
+	if _, err := tx.Exec(ctx, `insert into email_status_history(id,email_record_id,status,message,meta,created_at) values($1,$2,$3,$4,null,now())`, uuid.NewString(), recordID, "sent", "email sent successfully"); err != nil {
 		return err
 	}
-
 	return tx.Commit(ctx)
 }
 
@@ -82,15 +69,9 @@ func (s *Store) MarkFailed(ctx context.Context, recordID, reason string) error {
 	if err != nil {
 		return err
 	}
-	defer func() {
-		_ = tx.Rollback(ctx)
-	}()
+	defer func() { _ = tx.Rollback(ctx) }()
 
-	ct, err := tx.Exec(
-		ctx,
-		`update email_records set status='failed', updated_at=now() where id=$1`,
-		recordID,
-	)
+	ct, err := tx.Exec(ctx, `update email_records set status='failed', updated_at=now() where id=$1`, recordID)
 	if err != nil {
 		return err
 	}
@@ -98,16 +79,82 @@ func (s *Store) MarkFailed(ctx context.Context, recordID, reason string) error {
 		return ErrEmailRecordNotFound
 	}
 
-	if _, err := tx.Exec(
-		ctx,
-		`insert into email_status_history(id,email_record_id,status,message,meta,created_at) values($1,$2,$3,$4,null,now())`,
-		uuid.NewString(),
-		recordID,
-		"failed",
-		reason,
-	); err != nil {
+	if _, err := tx.Exec(ctx, `insert into email_status_history(id,email_record_id,status,message,meta,created_at) values($1,$2,$3,$4,null,now())`, uuid.NewString(), recordID, "failed", reason); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+func (s *Store) MarkBounced(ctx context.Context, recordID, reason, bounceType string, smtpCode, retryCount int) error {
+	if s.DB == nil {
+		return ErrNilDB
+	}
+	if strings.TrimSpace(recordID) == "" {
+		return ErrEmptyRecordID
+	}
+	if strings.TrimSpace(reason) == "" {
+		reason = "email bounced"
+	}
+	if strings.TrimSpace(bounceType) == "" {
+		bounceType = "unknown"
+	}
+
+	metaJSON, err := json.Marshal(map[string]any{"bounce_type": bounceType, "smtp_code": smtpCode, "retry_count": retryCount})
+	if err != nil {
 		return err
 	}
 
+	tx, err := s.DB.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	ct, err := tx.Exec(ctx, `update email_records set status='bounced', updated_at=now() where id=$1`, recordID)
+	if err != nil {
+		return err
+	}
+	if ct.RowsAffected() == 0 {
+		return ErrEmailRecordNotFound
+	}
+
+	if _, err := tx.Exec(ctx, `insert into email_status_history(id,email_record_id,status,message,meta,created_at) values($1,$2,$3,$4,$5::jsonb,now())`, uuid.NewString(), recordID, "bounced", reason, string(metaJSON)); err != nil {
+		return err
+	}
 	return tx.Commit(ctx)
+}
+
+func (s *Store) Blacklist(ctx context.Context, emailAddr, reason string) error {
+	if s.DB == nil {
+		return ErrNilDB
+	}
+	emailAddr = strings.TrimSpace(strings.ToLower(emailAddr))
+	if emailAddr == "" {
+		return ErrEmptyEmail
+	}
+	if strings.TrimSpace(reason) == "" {
+		reason = "hard bounce"
+	}
+	_, err := s.DB.Exec(ctx, `
+insert into email_blacklist(id,email,reason,created_at,updated_at)
+values($1,$2,$3,now(),now())
+on conflict (email)
+do update set reason=excluded.reason, updated_at=now()
+`, uuid.NewString(), emailAddr, reason)
+	return err
+}
+
+func (s *Store) IsBlacklisted(ctx context.Context, emailAddr string) (bool, error) {
+	if s.DB == nil {
+		return false, ErrNilDB
+	}
+	emailAddr = strings.TrimSpace(strings.ToLower(emailAddr))
+	if emailAddr == "" {
+		return false, ErrEmptyEmail
+	}
+	var exists bool
+	if err := s.DB.QueryRow(ctx, `select exists(select 1 from email_blacklist where email=$1)`, emailAddr).Scan(&exists); err != nil {
+		return false, err
+	}
+	return exists, nil
 }

--- a/services/email-worker/internal/store/store_integration_test.go
+++ b/services/email-worker/internal/store/store_integration_test.go
@@ -129,7 +129,7 @@ func mustTestDB(t *testing.T) *pgxpool.Pool {
 
 func applyMigrations(t *testing.T, db *pgxpool.Pool) {
 	t.Helper()
-	for _, name := range []string{"001_init.sql", "002_authn_core.sql", "003_multitenant.sql", "004_email_service.sql", "005_email_verifications_token_hash_scope.sql"} {
+	for _, name := range []string{"001_init.sql", "002_authn_core.sql", "003_multitenant.sql", "004_email_service.sql", "005_email_verifications_token_hash_scope.sql", "006_email_blacklist.sql"} {
 		sqlPath := filepath.Join(migrationsDir(t), name)
 		sqlBytes, err := os.ReadFile(sqlPath)
 		if err != nil {
@@ -148,7 +148,8 @@ truncate table
   email_status_history,
   email_records,
   email_jobs,
-  email_verifications
+  email_verifications,
+  email_blacklist
 restart identity cascade`); err != nil {
 		t.Fatalf("truncate email tables: %v", err)
 	}
@@ -165,4 +166,55 @@ func migrationsDir(t *testing.T) string {
 		t.Fatalf("migrations dir not found: %s (%v)", dir, err)
 	}
 	return dir
+}
+
+func TestMarkBounced_StoresBounceMeta(t *testing.T) {
+	db := mustTestDB(t)
+	truncateEmailTables(t, db)
+
+	recordID := "rec-mark-bounced"
+	if _, err := db.Exec(context.Background(), `
+insert into email_records(id,to_email,status,created_at,updated_at)
+values($1,$2,'queued',now(),now())`,
+		recordID,
+		"user@example.com",
+	); err != nil {
+		t.Fatalf("insert email record: %v", err)
+	}
+
+	s := &Store{DB: db}
+	if err := s.MarkBounced(context.Background(), recordID, "550 mailbox unavailable", "hard", 550, 0); err != nil {
+		t.Fatalf("mark bounced: %v", err)
+	}
+
+	var status, bounceType string
+	var smtpCode int
+	if err := db.QueryRow(context.Background(), `
+select status, meta->>'bounce_type', (meta->>'smtp_code')::int
+from email_status_history
+where email_record_id=$1
+order by created_at desc
+limit 1`, recordID).Scan(&status, &bounceType, &smtpCode); err != nil {
+		t.Fatalf("query status history: %v", err)
+	}
+	if status != "bounced" || bounceType != "hard" || smtpCode != 550 {
+		t.Fatalf("got status=%q bounce_type=%q smtp_code=%d", status, bounceType, smtpCode)
+	}
+}
+
+func TestBlacklistAndIsBlacklisted(t *testing.T) {
+	db := mustTestDB(t)
+	truncateEmailTables(t, db)
+
+	s := &Store{DB: db}
+	if err := s.Blacklist(context.Background(), "User@Example.com", "hard bounce"); err != nil {
+		t.Fatalf("blacklist: %v", err)
+	}
+	blacklisted, err := s.IsBlacklisted(context.Background(), "user@example.com")
+	if err != nil {
+		t.Fatalf("is blacklisted: %v", err)
+	}
+	if !blacklisted {
+		t.Fatal("expected email to be blacklisted")
+	}
 }


### PR DESCRIPTION
### Motivation

- Surface SMTP delivery outcomes to the worker so hard bounces can be blacklisted and soft bounces retried instead of blindly failing. 
- Persist bounce metadata and blacklist state in the database so subsequent sends avoid known-bad recipients. 
- Provide deterministic retry scheduling for transient (soft) bounces and prevent infinite retries.

### Description

- Add DB migration `006_email_blacklist.sql` to create `email_blacklist` table and index, and update test harness to apply the new migration in `ApplyMigrations` and test helpers. 
- Extend the sender package with SMTP error classification (`ClassifySMTPError`, `BounceClassification`, `BounceType`) and a `DeliveryError` wrapper so delivery results include bounce type and SMTP code. 
- Enhance the consumer to detect blacklisted recipients, handle delivery errors via new `handleDeliveryError` logic, mark bounced records with metadata, blacklist hard-bounced addresses, and schedule soft-bounce retries using a `Scheduler` interface and configured `softBounceRetryIntervals`. 
- Add queue `EnqueueContext` method usage to requeue retries and introduce `RetryCount` on `EmailJob`. 
- Extend the store with `MarkBounced`, `Blacklist`, and `IsBlacklisted` methods that persist bounce state and blacklist entries and return appropriate errors; minor refactors to `MarkSent`/`MarkFailed` transaction handling. 
- Add unit and integration tests: bounce classification tests, sender tests expecting `DeliveryError`, consumer tests for hard/soft bounce behavior and retry scheduling, and integration tests for `MarkBounced`, `Blacklist`, and `IsBlacklisted`. Also add test helpers and fakes (`fakeQueue`, `fakeScheduler`, `fakeStore`) to exercise retry and blacklist flows.

### Testing

- Unit tests were added for bounce classification (`sender`), sender delivery wrapping, and consumer behavior (hard bounce blacklisting, soft-bounce retry enqueuing, and blacklist short-circuiting); these unit tests run with `go test` and passed in the local test runs. 
- Integration tests for store operations (`MarkBounced`, `Blacklist`, `IsBlacklisted`) were added and run against a configured test database when `TEST_DB_DSN` is present, and passed in those environments. 
- Existing test harness was updated (migrations and truncation) and the updated test suite ran successfully in CI/local runs with the required test env variables set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab83e875f88333895fd93b35e7e41a)